### PR TITLE
Potential fix for code scanning alert no. 160: Client-side cross-site scripting

### DIFF
--- a/src/agent_orchestrator/dashboard/static/app.js
+++ b/src/agent_orchestrator/dashboard/static/app.js
@@ -773,15 +773,30 @@
     // Show fallback log if any
     const fbLog = data.fallback_log || [];
     if (fbLog.length > 0) {
-      const fbHtml = fbLog.map(f => {
-        const icon = f.status === "ok" ? "&#10003;" : "&#10007;";
-        const cls = f.status === "ok" ? "fb-ok" : "fb-fail";
-        return `<span class="fb-entry ${cls}">${icon} ${esc(f.agent || "")} → ${esc(f.model)} [${f.status}] ${esc(f.detail || "")}</span>`;
-      }).join("");
       addSystemBubble("Fallback log:");
       const fbBubble = document.createElement("div");
       fbBubble.className = "chat-bubble system fallback-log";
-      fbBubble.innerHTML = fbHtml;
+      fbLog.forEach(f => {
+        const iconChar = f.status === "ok" ? "✔" : "✗";
+        const cls = f.status === "ok" ? "fb-ok" : "fb-fail";
+        const span = document.createElement("span");
+        span.className = `fb-entry ${cls}`;
+
+        const iconNode = document.createTextNode(iconChar + " ");
+        span.appendChild(iconNode);
+
+        const agentText = (f.agent || "") + " \u2192 " + (f.model || "") + " [";
+        span.appendChild(document.createTextNode(agentText));
+
+        span.appendChild(document.createTextNode(f.status || ""));
+        span.appendChild(document.createTextNode("] "));
+
+        if (f.detail) {
+          span.appendChild(document.createTextNode(f.detail));
+        }
+
+        fbBubble.appendChild(span);
+      });
       $chatMessages.appendChild(fbBubble);
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pjcau/agent-orchestrator/security/code-scanning/160](https://github.com/pjcau/agent-orchestrator/security/code-scanning/160)

To fix this, avoid writing tainted data via `innerHTML`, and instead construct the DOM nodes programmatically, assigning untrusted text via `textContent` (or `createTextNode`) and only using hard-coded values for classes and icons. This removes the XSS sink while preserving the existing UI.

Concretely, in `src/agent_orchestrator/dashboard/static/app.js`, within `_handleTeamComplete`, remove the string-building of `fbHtml` and the assignment to `fbBubble.innerHTML`. Instead, for each entry in `fbLog`, create a `<span>` element, set its `className` to `"fb-entry fb-ok"` or `"fb-entry fb-fail"` based on `f.status`, and then append an icon node and text nodes built from the same content that was previously included in the template literal. Use `textContent` for any value that comes from `f` (`agent`, `model`, `detail`, `status`), and keep the arrows/brackets as literal strings. This retains the look while eliminating the need for HTML parsing of tainted input.

No extra imports or helper methods are strictly required; the existing `esc()` helper is no longer needed for these particular fields in this block if we assign everything via `textContent`, but we should leave it untouched elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
