### PR TITLE
chore(ci): opt JS-based actions into Node 24 runtime

### DIFF
--- a/.github/workflows/dead-code-audit.yml
+++ b/.github/workflows/dead-code-audit.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   audit:
     name: Find unused code

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,6 +19,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ concurrency:
 
 env:
   APP_DIR: /opt/agent-orchestrator
+  # Opt JS-based actions (actions/cache, actions/upload-artifact, ...)
+  # into the Node 24 runtime. Node 20 is deprecated on GitHub runners and
+  # will be removed on 2026-09-16. Remove this line once Node 24 is the
+  # default (announced for 2026-06-02).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   test:

--- a/.github/workflows/diagnose-monitoring.yml
+++ b/.github/workflows/diagnose-monitoring.yml
@@ -3,6 +3,9 @@ name: Diagnose Monitoring
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   diagnose:
     runs-on: ubuntu-latest

--- a/.github/workflows/fetch-logs.yml
+++ b/.github/workflows/fetch-logs.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: "dashboard,nginx,postgres,prometheus,grafana,redis,aws-cost-exporter"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   fetch-logs:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-research.yml
+++ b/.github/workflows/nightly-research.yml
@@ -15,6 +15,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   research:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-autofix.yml
+++ b/.github/workflows/security-autofix.yml
@@ -11,6 +11,9 @@ permissions:
   pull-requests: write
   security-events: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   autofix:
     name: Fix Code Scanning Alerts

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # --- Python dependency audit ---
   dependency-audit:


### PR DESCRIPTION
## Summary

GitHub deprecated the Node 20 runtime used by JS-based actions (`actions/cache`, `actions/upload-artifact`, `actions/setup-*`, `actions/checkout`, …). The Deploy workflow has been printing this warning since the last push to main:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

Per [GitHub's guidance](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), the recommended way to opt in early is to set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow level.

This PR adds that env var to **every workflow that uses a JS-based action** — 8 files. Once Node 24 becomes the default (announced for 2026-06-02) the flag is a no-op and can be removed in a follow-up.

## Files touched

- `.github/workflows/deploy.yml`
- `.github/workflows/dead-code-audit.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/workflows/diagnose-monitoring.yml`
- `.github/workflows/fetch-logs.yml`
- `.github/workflows/nightly-research.yml`
- `.github/workflows/security-autofix.yml`
- `.github/workflows/security-scan.yml`

## Test plan

- [x] All 8 workflow YAML files parse cleanly via `yaml.safe_load`
- [x] Each workflow's top-level `env.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` resolves to `"true"`
- [x] `pytest tests/test_ci_workflows.py tests/test_deploy.py` — 51 pass (workflow structure invariants intact)
- [ ] Post-merge CI run on main — confirm the deprecation warning no longer appears in the Deploy summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)