### PR TITLE
feat(ui-mobile): safe-area, gear next to New Chat, PresetsBar spacing

### DIFF
--- a/frontend/.responsive-baseline.txt
+++ b/frontend/.responsive-baseline.txt
@@ -1,6 +1,6 @@
 # Pre-existing responsive violations — do not add new entries here.
 # Migrate listed sites to BP.* / useBreakpoint() then re-run with --update-baseline.
-frontend/src/index.css:1497:@media (max-width: 900px) {
-frontend/src/index.css:1847:@media (max-width: 600px) {
+frontend/src/index.css:1510:@media (max-width: 900px) {
+frontend/src/index.css:1860:@media (max-width: 600px) {
 frontend/src/pages/DashboardPage.tsx:25:  window.matchMedia("(max-width: 600px)").matches;
 frontend/src/stores/useAppStore.ts:249:    typeof window === "undefined" || window.matchMedia("(max-width: 600px)").matches

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>Agent Orchestrator Dashboard</title>
     <link
       rel="stylesheet"

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -301,18 +301,9 @@ export function ChatInput({
 
       {/* Controls row.
           On mobile (<=600px) the mode/provider selects collapse behind the
-          gear button so the chat keeps as much vertical space as possible. */}
+          gear button (rendered in the actions row at the bottom of this
+          component) so the chat keeps as much vertical space as possible. */}
       <div className={`chat-input__controls ${advOpen ? "chat-input__controls--adv" : ""}`}>
-        <button
-          type="button"
-          className="btn-icon chat-input__adv-toggle"
-          onClick={() => setAdvOpen((o) => !o)}
-          aria-label={advOpen ? "Hide advanced options" : "Show advanced options"}
-          aria-expanded={advOpen}
-          title="Advanced options"
-        >
-          ⚙
-        </button>
         {/* Mobile-only segment controls (CSS-toggled). They replace the native
             <select> pickers for mode + provider which can render misaligned
             inside emulators / certain mobile browsers. The selects below
@@ -514,10 +505,20 @@ export function ChatInput({
         </button>
       </div>
 
-      {/* Action bar */}
+      {/* Action bar — primary on the left, settings gear on the right. */}
       <div className="chat-input__actions">
         <button className="btn-text" onClick={onNewChat} disabled={isDisabled}>
           New Chat
+        </button>
+        <button
+          type="button"
+          className="btn-icon chat-input__adv-toggle"
+          onClick={() => setAdvOpen((o) => !o)}
+          aria-label={advOpen ? "Hide advanced options" : "Show advanced options"}
+          aria-expanded={advOpen}
+          title="Advanced options"
+        >
+          ⚙
         </button>
       </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -60,7 +60,11 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 20px;
+  /* Respect iOS notch / dynamic island on top and the curved corners on
+     the sides. env() falls back to 0 on browsers without safe-area support
+     so desktop layouts remain unchanged. */
+  padding: max(6px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right))
+           6px max(20px, env(safe-area-inset-left));
   background: var(--bg-card);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -794,7 +798,10 @@ body {
 .chat-input {
   border-top: 1px solid var(--border);
   background: var(--bg-card);
-  padding: 10px 16px;
+  /* Reserve room for the iOS home indicator and side curves. */
+  padding: 10px max(16px, env(safe-area-inset-right))
+           max(10px, env(safe-area-inset-bottom))
+           max(16px, env(safe-area-inset-left));
   flex-shrink: 0;
 }
 
@@ -963,7 +970,13 @@ body {
 .btn-send:hover { opacity: 0.85; }
 .btn-send:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.chat-input__actions { display: flex; gap: 8px; margin-top: 6px; }
+.chat-input__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 6px;
+}
 
 /* === Sidebar === */
 .sidebar {
@@ -1504,22 +1517,22 @@ body {
 .presets-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  padding: 4px 16px 0;
+  gap: 8px;
+  padding: 8px 16px 10px;
   align-items: center;
 }
 
 .preset-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 12px;
   color: var(--text-dim);
   font-size: 11px;
   font-family: var(--font-mono);
-  padding: 2px 8px;
+  padding: 4px 12px;
   cursor: pointer;
   transition: border-color 0.15s, color 0.15s;
 }
@@ -1969,9 +1982,19 @@ body {
          Native selects are hidden in favour of segment controls (below) — the
          <select> pickers misalign in some mobile browsers / emulators and the
          option lists are short enough to fit as inline buttons. The <select>
-         elements still exist in the DOM but visually swap with the segments. */
+         elements still exist in the DOM but visually swap with the segments.
+         Other controls (model picker, RAG checkbox, stream toggle) stay
+         visible by default — only the segment radios collapse behind ⚙. */
   .chat-input__adv-toggle { display: inline-flex; }
   .chat-input__select--adv { display: none !important; }
+  /* Breathing room between PresetsBar pills + away from the textarea below. */
+  .presets-bar { gap: 10px; padding: 10px 12px 14px; row-gap: 10px; }
+  .preset-btn { padding: 8px 14px; font-size: 12px; }
+  /* Make the gear feel like an end-aligned secondary action next to New Chat. */
+  .chat-input__actions { padding: 2px 4px; }
+  .chat-input__actions .chat-input__adv-toggle {
+    border-radius: 999px;
+  }
   .chat-input__controls--adv .chat-input__segment {
     display: flex;
     flex: 1 1 100%;


### PR DESCRIPTION
## Summary

Mobile UI polish driven by direct iPhone 12 Pro testing:

1. **Top-right header was clipped behind the safe area** (notch/dynamic island). Adds `viewport-fit=cover` and `env(safe-area-inset-*)` padding to `.app-header` and `.chat-input` so content stays inside the visible area on iOS. Desktop unaffected (env() falls back to 0).

2. **⚙ gear moved from the controls row at the top of the chat input to the actions bar at the bottom**, anchored to the right of New Chat — a single place to find tertiary controls. The mode/provider segment radios continue to collapse behind it; the model picker, RAG toggle, and stream toggle remain visible by default on mobile.

3. **PresetsBar pills (Explain, Review, …) were too cramped** — gaps and padding were ~4px, the buttons collided with each other and the textarea below. Bumped gap to 8/10px and padding to 4px×12px / 8px×14px on mobile.

Also merges in the recent `chore/force-node24-actions` from main so this branch starts CI clean.

## Test plan

- [x] `pytest` — 2191 passed, 5 skipped (deselected the pre-existing python-multipart upload tests — unrelated)
- [x] `npm test` — 17 files / 118 tests pass
- [x] `npm run e2e` — 2 passed (mobile + desktop)
- [x] `bash scripts/check_responsive.sh` — OK (baseline regenerated for line-shift only)
- [x] Manual on iPhone 12 Pro: header no longer clipped; PresetsBar pills have breathing room; ⚙ visible bottom-right of input area

## Responsive check

- [x] Tested at 375px (Playwright mobile) and at iPhone 12 Pro (390×844)
- [x] Tested at 1440px (Playwright desktop)
- [x] No new hardcoded breakpoints
- [x] No literal `window.innerWidth` reads
- [x] Animations honor `prefers-reduced-motion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)