### PR TITLE
feat(dashboard): per-user history isolation on /api/jobs/* (Phase 7.15)

### DIFF
--- a/src/agent_orchestrator/dashboard/agent_runtime_router.py
+++ b/src/agent_orchestrator/dashboard/agent_runtime_router.py
@@ -58,6 +58,17 @@ def _safe_log(value: str) -> str:
     return str(value).replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
 
 
+def _current_user_id(request: Request) -> str | None:
+    """Return the canonical owner id for the request, or ``None`` if the
+    request is unauthenticated (dev mode / API-key access). Used by
+    Phase 7.15 to label per-user session ownership."""
+    user = getattr(request.state, "user", None)
+    if not isinstance(user, dict):
+        return None
+    sub = user.get("sub") or user.get("email") or user.get("github_login")
+    return str(sub).strip() if sub else None
+
+
 runtime_router = APIRouter(tags=["runtime"])
 
 # Allowed Ollama URL prefixes (SSRF protection)
@@ -593,6 +604,14 @@ async def team_run(body: dict, request: Request):
     openrouter_key = os.environ.get("OPENROUTER_API_KEY", "")
     provider = _make_provider(model, provider_type, ollama_url, openrouter_key)
 
+    # Phase 7.15 — record the authenticated user as the session owner so the
+    # /api/jobs/* endpoints can filter history per-user. Falls back to the
+    # shared bucket in dev mode (no JWT) or API-key access.
+    owner = _current_user_id(request)
+    job_logger.touch()  # rotates session if expired; capture session_id AFTER
+    job_logger.set_session_owner(owner)
+    session_id = job_logger.session_id
+
     # Evict completed/failed jobs to prevent unbounded growth (keep last 20)
     finished = [k for k, v in active_jobs.items() if v["status"] != "running"]
     for k in finished[:-20]:
@@ -601,6 +620,8 @@ async def team_run(body: dict, request: Request):
     active_jobs[job_id] = {
         "status": "running",
         "task": task_desc,
+        "session_id": session_id,
+        "owner": owner,
         "result": None,
         # `future` is set right after asyncio.create_task() below so
         # /api/team/{job_id}/cancel can reach into the active task.
@@ -744,7 +765,13 @@ async def team_run(body: dict, request: Request):
 
     future = asyncio.create_task(_run_in_background())
     active_jobs[job_id]["future"] = future
-    return JSONResponse(content={"job_id": job_id, "status": "started"})
+    # session_id is in the response so a polling client can immediately point
+    # at /api/jobs/<session_id>/files instead of guessing via /api/jobs/list.
+    return JSONResponse(content={
+        "job_id": job_id,
+        "session_id": session_id,
+        "status": "started",
+    })
 
 
 @runtime_router.post("/api/team/{job_id}/cancel")

--- a/src/agent_orchestrator/dashboard/gateway_api.py
+++ b/src/agent_orchestrator/dashboard/gateway_api.py
@@ -44,6 +44,33 @@ logger = logging.getLogger(__name__)
 
 gateway_router = APIRouter(prefix="/api", tags=["gateway"])
 
+
+# ---------------------------------------------------------------------------
+# Per-user session ownership (Phase 7.15)
+# ---------------------------------------------------------------------------
+
+
+def _current_user_id(request: Request) -> str | None:
+    """Return the canonical owner id (email) for the request, or None when
+    unauthenticated (dev mode / API-key access)."""
+    user = getattr(request.state, "user", None)
+    if not isinstance(user, dict):
+        return None
+    sub = user.get("sub") or user.get("email") or user.get("github_login")
+    return str(sub).strip() if sub else None
+
+
+def _check_session_access(session_id: str, request: Request) -> JSONResponse | None:
+    """Authorisation gate for /api/jobs/{session_id}/* endpoints.
+
+    Returns ``None`` on allow, or a 404 JSONResponse on deny. We pick 404
+    (rather than 403) on purpose: a foreign owner shouldn't be able to
+    probe which session_ids exist on the server."""
+    job_logger = request.app.state.job_logger
+    if not job_logger.user_can_access(session_id, _current_user_id(request)):
+        return JSONResponse(content={"error": "Session not found"}, status_code=404)
+    return None
+
 # ---------------------------------------------------------------------------
 # Module-level shared state for MCP registry
 # (populated lazily per-request from app.state when used standalone)
@@ -302,15 +329,23 @@ async def session_history(request: Request):
 
 @gateway_router.get("/jobs/list")
 async def jobs_list(request: Request):
-    """List all job sessions."""
+    """List sessions visible to the authenticated user.
+
+    Phase 7.15: the dashboard JobLogger now labels each session with the
+    JWT ``sub`` (email) of the user who first wrote to it. ``list_sessions``
+    returns the requester's own sessions plus the shared/anonymous pool
+    (which keeps dev mode working without auth)."""
     job_logger = request.app.state.job_logger
-    sessions = job_logger.list_sessions()
+    sessions = job_logger.list_sessions(user=_current_user_id(request))
     return JSONResponse(content={"sessions": sessions})
 
 
 @gateway_router.get("/jobs/{session_id}")
 async def jobs_detail(session_id: str, request: Request):
     """Load all records from a specific session."""
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     job_logger = request.app.state.job_logger
     records = job_logger.load_session(session_id)
     if not records:
@@ -321,6 +356,9 @@ async def jobs_detail(session_id: str, request: Request):
 @gateway_router.post("/jobs/{session_id}/switch")
 async def jobs_switch(session_id: str, request: Request):
     """Switch to an existing session to continue work in it."""
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     job_logger = request.app.state.job_logger
     ok = job_logger.switch_session(session_id)
     if not ok:
@@ -347,6 +385,9 @@ async def jobs_restore_conversation(session_id: str, request: Request):
 
     Returns the conversation_id (new or recovered from records).
     """
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     from ..core.conversation import ConversationMessage
 
     job_logger = request.app.state.job_logger
@@ -422,6 +463,9 @@ async def jobs_delete(session_id: str, request: Request):
     """Delete a session and its files. DB metrics are preserved."""
     import shutil
 
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     job_logger = request.app.state.job_logger
     session_dir = job_logger._base_dir / f"job_{session_id}"
     if not session_dir.exists() or not session_dir.is_dir():
@@ -448,6 +492,10 @@ async def jobs_delete(session_id: str, request: Request):
 async def jobs_files(session_id: str, request: Request):
     """List all files in a session directory (recursive tree)."""
     from pathlib import Path
+
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
 
     job_logger = request.app.state.job_logger
     session_dir = job_logger._base_dir / f"job_{session_id}"
@@ -501,6 +549,9 @@ async def jobs_files(session_id: str, request: Request):
 @gateway_router.get("/jobs/{session_id}/files/{filename:path}")
 async def jobs_file_content(session_id: str, filename: str, request: Request):
     """Read content of a file in a session directory."""
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     job_logger = request.app.state.job_logger
     session_dir = job_logger._base_dir / f"job_{session_id}"
     target = (session_dir / filename).resolve()
@@ -522,6 +573,9 @@ async def jobs_file_content(session_id: str, filename: str, request: Request):
 @gateway_router.get("/jobs/{session_id}/download")
 async def jobs_download_zip(session_id: str, request: Request):
     """Download entire session as a ZIP archive (recursive — includes subdirs)."""
+    deny = _check_session_access(session_id, request)
+    if deny is not None:
+        return deny
     import io
     import zipfile
 

--- a/src/agent_orchestrator/dashboard/job_logger.py
+++ b/src/agent_orchestrator/dashboard/job_logger.py
@@ -158,21 +158,83 @@ class JobLogger:
                 continue
         return records
 
-    def list_sessions(self) -> list[dict[str, Any]]:
-        """List all job sessions with summary info (excludes empty dirs)."""
+    # ------------------------------------------------------------------
+    # Ownership (per-user history isolation) — Phase 7.15
+    # ------------------------------------------------------------------
+    #
+    # Each session dir may carry a sidecar `.owner` file containing a
+    # single line — the canonical owner identifier (typically the logged-
+    # in user's email from the JWT `sub` claim). The dashboard writes it
+    # at session-create time and reads it for filtering. Sessions without
+    # the file are treated as `_ANON_OWNER` ("shared"), which preserves
+    # backwards compatibility with pre-existing on-disk sessions AND with
+    # dev mode (ALLOW_DEV_MODE=true), where there is no authenticated
+    # user. Only an explicit owner match unlocks ownership-gated
+    # endpoints; the shared bucket stays visible to everyone.
+
+    _ANON_OWNER = "shared"
+    _OWNER_FILE = ".owner"
+
+    def set_session_owner(self, owner: str | None) -> None:
+        """Record the owner of the CURRENT session, if not already set.
+
+        Idempotent: subsequent calls on the same session with a different
+        owner are ignored. ``None`` / empty string falls back to the
+        shared anonymous owner. The session directory is created if it
+        doesn't exist yet (the owner file is the first persisted
+        artefact of an authenticated session)."""
+        canonical = (owner or self._ANON_OWNER).strip() or self._ANON_OWNER
+        self._ensure_dir()
+        owner_path = self._session_dir / self._OWNER_FILE
+        if owner_path.exists():
+            return
+        try:
+            owner_path.write_text(canonical, encoding="utf-8")
+        except OSError:
+            pass  # never crash a team_run because of an ownership write
+
+    def get_session_owner(self, session_id: str) -> str:
+        """Return the owner of a session, or ``"shared"`` if not labelled."""
+        owner_file = self._base_dir / f"job_{session_id}" / self._OWNER_FILE
+        try:
+            return owner_file.read_text(encoding="utf-8").strip() or self._ANON_OWNER
+        except OSError:
+            return self._ANON_OWNER
+
+    def user_can_access(self, session_id: str, user: str | None) -> bool:
+        """Authorisation gate: a session is visible to its owner AND to
+        anyone when the session is in the shared bucket. ``user=None`` is
+        treated as the shared user (dev / unauthenticated)."""
+        owner = self.get_session_owner(session_id)
+        viewer = (user or self._ANON_OWNER).strip() or self._ANON_OWNER
+        return owner == self._ANON_OWNER or owner == viewer
+
+    def list_sessions(self, user: str | None = None) -> list[dict[str, Any]]:
+        """List job sessions visible to *user* (None → shared/dev mode).
+
+        A session is included when:
+          - it has at least one file (empty dirs are filtered)
+          - AND its owner equals *user* OR is the shared anonymous bucket.
+        """
+        viewer = (user or self._ANON_OWNER).strip() or self._ANON_OWNER
         sessions: list[dict[str, Any]] = []
         if not self._base_dir.exists():
             return sessions
         for d in sorted(self._base_dir.iterdir(), reverse=True):
             if not d.is_dir() or not d.name.startswith("job_"):
                 continue
-            # Skip empty directories (they'll be cleaned up)
-            if not any(d.iterdir()):
+            # Skip empty directories (they'll be cleaned up). The sidecar
+            # .owner file does NOT count as content for this check.
+            content = [c for c in d.iterdir() if c.name != self._OWNER_FILE]
+            if not content:
                 continue
-            session_id = d.name[4:]  # strip "job_" prefix
+            session_id = d.name[4:]
+            # Ownership filter.
+            owner = self.get_session_owner(session_id)
+            if not (owner == self._ANON_OWNER or owner == viewer):
+                continue
             json_files = sorted(d.glob("*.json"))
             record_count = len(json_files)
-            # Extract summary from first and last records
             first_prompt = ""
             last_type = ""
             if json_files:
@@ -183,8 +245,8 @@ class JobLogger:
                     last_type = last.get("job_type", "")
                 except (json.JSONDecodeError, OSError):
                     pass
-            # Count non-json files (agent-created files)
-            all_files = [f for f in d.iterdir() if f.is_file() and f.suffix != ".json"]
+            all_files = [f for f in d.iterdir()
+                         if f.is_file() and f.suffix != ".json" and f.name != self._OWNER_FILE]
             sessions.append(
                 {
                     "session_id": session_id,
@@ -194,6 +256,7 @@ class JobLogger:
                     "first_prompt": first_prompt,
                     "last_type": last_type,
                     "is_current": session_id == self._session_id,
+                    "owner": owner,
                 }
             )
         return sessions

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2075,3 +2075,71 @@ class TestUploadEndpoint:
             )
 
         assert resp.status_code == 400
+
+
+class TestPerUserHistory:
+    """Phase 7.15 — per-user history isolation on the JobLogger."""
+
+    def test_anonymous_session_visible_to_everyone(self, tmp_path):
+        from agent_orchestrator.dashboard.job_logger import JobLogger
+        logger = JobLogger(jobs_dir=str(tmp_path))
+        logger.touch()
+        logger.log("team_run", {"task": "anon work"})
+        assert logger.get_session_owner(logger.session_id) == "shared"
+        # Both an authed user and a passer-by see the session.
+        assert any(s["session_id"] == logger.session_id
+                   for s in logger.list_sessions(user="alice@example.com"))
+        assert any(s["session_id"] == logger.session_id
+                   for s in logger.list_sessions(user=None))
+
+    def test_owned_session_only_visible_to_owner(self, tmp_path):
+        from agent_orchestrator.dashboard.job_logger import JobLogger
+        logger = JobLogger(jobs_dir=str(tmp_path))
+        logger.touch()
+        logger.set_session_owner("alice@example.com")
+        logger.log("team_run", {"task": "alice work"})
+        sid = logger.session_id
+
+        alice_sees = [s["session_id"] for s in logger.list_sessions(user="alice@example.com")]
+        bob_sees = [s["session_id"] for s in logger.list_sessions(user="bob@example.com")]
+        anon_sees = [s["session_id"] for s in logger.list_sessions(user=None)]
+
+        assert sid in alice_sees
+        assert sid not in bob_sees     # cross-user isolation
+        assert sid not in anon_sees    # logged-out viewers can't see owned sessions
+
+    def test_set_session_owner_is_idempotent(self, tmp_path):
+        from agent_orchestrator.dashboard.job_logger import JobLogger
+        logger = JobLogger(jobs_dir=str(tmp_path))
+        logger.touch()
+        logger.set_session_owner("alice@example.com")
+        logger.set_session_owner("bob@example.com")   # ignored
+        assert logger.get_session_owner(logger.session_id) == "alice@example.com"
+
+    def test_user_can_access_gate(self, tmp_path):
+        from agent_orchestrator.dashboard.job_logger import JobLogger
+        logger = JobLogger(jobs_dir=str(tmp_path))
+        logger.touch()
+        logger.set_session_owner("alice@example.com")
+        sid = logger.session_id
+        assert logger.user_can_access(sid, "alice@example.com") is True
+        assert logger.user_can_access(sid, "bob@example.com") is False
+        assert logger.user_can_access(sid, None) is False
+        # An unlabelled session (no .owner file) is shared → everyone passes.
+        logger2 = JobLogger(jobs_dir=str(tmp_path))
+        logger2.touch()
+        logger2.log("team_run", {"task": "no owner"})
+        sid2 = logger2.session_id
+        assert logger.user_can_access(sid2, "anyone@example.com") is True
+        assert logger.user_can_access(sid2, None) is True
+
+    def test_list_sessions_ignores_owner_file_for_emptiness(self, tmp_path):
+        """A session containing ONLY the .owner sidecar is still empty
+        and must not appear in the list."""
+        from agent_orchestrator.dashboard.job_logger import JobLogger
+        logger = JobLogger(jobs_dir=str(tmp_path))
+        logger.touch()
+        logger.set_session_owner("alice@example.com")
+        # No log() call → only .owner exists in the dir.
+        sids = [s["session_id"] for s in logger.list_sessions(user="alice@example.com")]
+        assert logger.session_id not in sids


### PR DESCRIPTION
## Summary

Multi-tenant fix for the dashboard. Today the `/api/jobs/*` endpoints expose a single global history pool — any logged-in user can list, read, download, switch into and delete every other user's sessions. This PR labels each session with the owner's JWT `sub` and filters all the read/write paths accordingly.

## What changed

**`JobLogger`** (`src/agent_orchestrator/dashboard/job_logger.py`)
- New `.owner` sidecar file inside each session dir (one line, the canonical owner id — typically the JWT `sub` / email).
- `set_session_owner(owner)` writes it (idempotent — first writer wins).
- `get_session_owner(session_id)` reads it; falls back to `"shared"` when the file is missing (backward compat with pre-existing on-disk sessions AND dev mode / API-key access).
- `user_can_access(session_id, user)` — single gate function.
- `list_sessions(user=None)` now returns shared-pool sessions PLUS the requester's own. Empty-dir filter ignores the `.owner` sidecar.
- Each list row also gets an `"owner"` field.

**`agent_runtime_router.team_run`**
- New `_current_user_id(request)` helper reads `request.state.user.sub` (set by the existing auth middleware) and returns `None` for unauthenticated requests.
- Before scheduling the background task, `set_session_owner()` labels the session and the `session_id` is captured into `active_jobs[job_id]`.
- The POST `/api/team/run` response now includes `session_id` so polling clients don't have to guess via `/api/jobs/list` (closes the 2026-05-17 "wrong session scored 16/100" follow-up too).

**`gateway_api`**
- New `_check_session_access(session_id, request)` gate; returns 404 (not 403 — prevents probing).
- Applied to `GET /api/jobs/{id}`, `/switch`, `/restore`, `DELETE /api/jobs/{id}`, `/files`, `/files/{path}`, `/download`.
- `/api/jobs/list` now passes `user=_current_user_id(request)`.

## Behaviour matrix

| Session label | Viewer | Visible? |
|---|---|---|
| `shared` (no `.owner`) | any user | ✅ yes (dev mode, legacy sessions) |
| `alice@example.com` | `alice@example.com` | ✅ yes |
| `alice@example.com` | `bob@example.com` | ❌ no |
| `alice@example.com` | unauthenticated | ❌ no |

## Tests

5 new cases in `tests/test_dashboard.py::TestPerUserHistory`:
- anonymous session visible to everyone
- owned session ONLY visible to owner (cross-user isolation)
- `set_session_owner` is idempotent
- `user_can_access` gate semantics (owner / shared / cross-user / dev)
- `list_sessions` ignores `.owner` for emptiness check

**Full suite: 2250 passed**, 6 pre-existing failures **unrelated** to this change (`tests/test_agents_registry.py::TestHealthcareAgents` and `::TestAgentDefaultModel` — already broken on `origin/main`).

## Known caveat (out of scope)

`JobLogger` is still a process-wide singleton: `current_session_id` is shared across the dashboard, so a `/switch` by user A is observable process-wide. This PR isolates the LIST and PROTECTS per-session endpoints; multi-tenant **current**-session needs a follow-up that scopes the current pointer per-user (likely `dict[user_id, session_id]` on `app.state` plus a request-scoped lookup).

## Test plan

- [ ] `pytest tests/test_dashboard.py::TestPerUserHistory -v`
- [ ] Manually:
  - Log in as user A → run a team job → verify `/api/jobs/list` shows it
  - Log in as user B → verify `/api/jobs/list` does NOT show user A's session
  - User B tries `GET /api/jobs/<A_session_id>/files` → 404 (not 403)
- [ ] Dev mode (`ALLOW_DEV_MODE=true`) still lists everything in the shared pool
- [ ] Pre-existing sessions on disk (no `.owner`) remain visible to all users

🤖 Generated with [Claude Code](https://claude.com/claude-code)