### PR TITLE
chore(deps): combined bump — 10 deps + 1 CI action

### DIFF
--- a/.github/workflows/aws-cost-audit.yml
+++ b/.github/workflows/aws-cost-audit.yml
@@ -221,7 +221,7 @@ jobs:
           cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: aws-cost-audit-report
           path: audit-report.md

--- a/.github/workflows/aws-prune.yml
+++ b/.github/workflows/aws-prune.yml
@@ -273,7 +273,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: aws-prune-report
           path: prune-report.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,43 +12,43 @@ dependencies = ["pyyaml>=6.0"]
 [project.optional-dependencies]
 # --- Harness layer (publishable library: core/, providers/, skills/) ---
 anthropic = ["anthropic>=0.40"]
-openai = ["openai>=2.37.0"]
+openai = ["openai>=2.38.0"]
 google = ["google-generativeai>=0.8"]
 postgres = ["asyncpg>=0.31.0"]
 harness = [
     "anthropic>=0.40",
-    "openai>=2.37.0",
+    "openai>=2.38.0",
     "google-generativeai>=0.8",
     "asyncpg>=0.31.0",
 ]
 
 # --- App layer (dashboard/, integrations/ — NOT part of library) ---
 slack = ["slack-bolt>=1.28.0", "slack-sdk>=3.33"]
-dashboard = ["fastapi>=0.115", "uvicorn[standard]>=0.47.0", "websockets>=16.0", "httpx>=0.27", "authlib>=1.7.2", "PyJWT>=2.12.1", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.20", "cryptography>=46.0.7"]
+dashboard = ["fastapi>=0.115", "uvicorn[standard]>=0.47.0", "websockets>=16.0", "httpx>=0.28.1", "authlib>=1.7.2", "PyJWT>=2.13.0", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.20", "cryptography>=48.0.0"]
 telegram = ["python-telegram-bot>=22.7"]
-docs = ["pymupdf>=1.27.2.2", "openpyxl>=3.1.5", "python-docx>=1.1", "python-pptx>=1.0.2", "markdownify>=0.13"]
+docs = ["pymupdf>=1.27.2.2", "openpyxl>=3.1.5", "python-docx>=1.1", "python-pptx>=1.0.2", "markdownify>=1.2.2"]
 # Image OCR — requires the `tesseract` system binary (apt install tesseract-ocr / brew install tesseract).
 images = ["pytesseract>=0.3.10", "Pillow>=10.0"]
 otel = [
     "opentelemetry-api>=1.41.1",
     "opentelemetry-sdk>=1.27",
-    "opentelemetry-instrumentation-fastapi>=0.48b0",
-    "opentelemetry-instrumentation-httpx>=0.63b0",
+    "opentelemetry-instrumentation-fastapi>=0.63b1",
+    "opentelemetry-instrumentation-httpx>=0.63b1",
     "opentelemetry-exporter-otlp-proto-http>=1.42.0",
     "opentelemetry-semantic-conventions>=0.49b0",
 ]
-langfuse = ["langfuse>=2.0"]
-phoenix = ["arize-phoenix-otel>=0.5"]
+langfuse = ["langfuse>=4.6.1"]
+phoenix = ["arize-phoenix-otel>=0.16.1"]
 
 # --- Rust acceleration (optional — falls back to pure Python) ---
 rust = ["agent-orchestrator-rust"]
 
 # --- Combined extras ---
-all = ["anthropic>=0.40", "openai>=2.37.0", "google-generativeai>=0.8", "asyncpg>=0.31.0", "fastapi>=0.115", "uvicorn[standard]>=0.47.0", "websockets>=16.0", "httpx>=0.27", "authlib>=1.7.2", "PyJWT>=2.12.1", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.20", "cryptography>=46.0.7", "pytesseract>=0.3.10", "Pillow>=10.0", "opentelemetry-api>=1.41.1", "opentelemetry-sdk>=1.27", "opentelemetry-instrumentation-fastapi>=0.48b0", "opentelemetry-instrumentation-httpx>=0.63b0", "opentelemetry-exporter-otlp-proto-http>=1.42.0", "opentelemetry-semantic-conventions>=0.49b0", "langfuse>=2.0", "arize-phoenix-otel>=0.5"]
+all = ["anthropic>=0.40", "openai>=2.38.0", "google-generativeai>=0.8", "asyncpg>=0.31.0", "fastapi>=0.115", "uvicorn[standard]>=0.47.0", "websockets>=16.0", "httpx>=0.28.1", "authlib>=1.7.2", "PyJWT>=2.13.0", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.20", "cryptography>=48.0.0", "pytesseract>=0.3.10", "Pillow>=10.0", "opentelemetry-api>=1.41.1", "opentelemetry-sdk>=1.27", "opentelemetry-instrumentation-fastapi>=0.63b1", "opentelemetry-instrumentation-httpx>=0.63b1", "opentelemetry-exporter-otlp-proto-http>=1.42.0", "opentelemetry-semantic-conventions>=0.49b0", "langfuse>=4.6.1", "arize-phoenix-otel>=0.16.1"]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
-    "ruff>=0.8",
+    "ruff>=0.15.14",
     "vulture>=2.16",
 ]
 


### PR DESCRIPTION
## Summary

Combines 11 dependabot PRs into one. All `pyproject.toml` upper-bound bumps + one GitHub Actions bump. Verified locally against the full test suite.

Replaces:
- ci: #134 `actions/upload-artifact` v4 → v7
- deps: #135 `cryptography` ≥46.0.7 → ≥48.0.0
- deps: #136 `httpx` ≥0.27 → ≥0.28.1
- deps: #137 `markdownify` ≥0.13 → ≥1.2.2
- deps: #138 `arize-phoenix-otel` ≥0.5 → ≥0.16.1
- deps: #139 `opentelemetry-instrumentation-fastapi` ≥0.48b0 → ≥0.63b1
- deps: #140 `opentelemetry-instrumentation-httpx` ≥0.63b0 → ≥0.63b1
- deps: #141 `ruff` ≥0.8 → ≥0.15.14
- deps: #142 `PyJWT` ≥2.12.1 → ≥2.13.0
- deps: #143 `openai` ≥2.37.0 → ≥2.38.0
- deps: #144 `langfuse` ≥2.0 → ≥4.6.1

Not included:
- #133 `actions/checkout` v5 → v6 — a code comment in `.github/workflows/security-scan.yml:118-120` documents that v6 regresses `fetch-depth: 0` with "could not read Username". Will be closed as won't-fix.

## Verification

- `pytest tests/` → **2286 passed, 10 skipped** (42s)
- `ruff check src/ tests/` → clean (with bumped ruff 0.15.14)

## Test plan

- [x] Full unit suite
- [x] Lint
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)