### PR TITLE
deps: batch 5 pip bumps (otel, langfuse, pytesseract)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,23 +28,23 @@ dashboard = ["fastapi>=0.115", "uvicorn[standard]>=0.49.0", "websockets>=16.0", 
 telegram = ["python-telegram-bot>=22.7"]
 docs = ["pymupdf>=1.27.2.2", "openpyxl>=3.1.5", "python-docx>=1.2.0", "python-pptx>=1.0.2", "markdownify>=1.2.2"]
 # Image OCR — requires the `tesseract` system binary (apt install tesseract-ocr / brew install tesseract).
-images = ["pytesseract>=0.3.10", "Pillow>=10.0"]
+images = ["pytesseract>=0.3.13", "Pillow>=10.0"]
 otel = [
-    "opentelemetry-api>=1.41.1",
-    "opentelemetry-sdk>=1.27",
+    "opentelemetry-api>=1.42.1",
+    "opentelemetry-sdk>=1.42.1",
     "opentelemetry-instrumentation-fastapi>=0.63b1",
     "opentelemetry-instrumentation-httpx>=0.63b1",
     "opentelemetry-exporter-otlp-proto-http>=1.42.0",
-    "opentelemetry-semantic-conventions>=0.49b0",
+    "opentelemetry-semantic-conventions>=0.63b1",
 ]
-langfuse = ["langfuse>=4.6.1"]
+langfuse = ["langfuse>=4.7.1"]
 phoenix = ["arize-phoenix-otel>=0.16.1"]
 
 # --- Rust acceleration (optional — falls back to pure Python) ---
 rust = ["agent-orchestrator-rust"]
 
 # --- Combined extras ---
-all = ["anthropic>=0.105.2", "openai>=2.41.0", "google-generativeai>=0.8.6", "asyncpg>=0.31.0", "fastapi>=0.115", "uvicorn[standard]>=0.49.0", "websockets>=16.0", "httpx>=0.28.1", "authlib>=1.7.2", "PyJWT>=2.13.0", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.31", "cryptography>=48.0.0", "pytesseract>=0.3.10", "Pillow>=10.0", "opentelemetry-api>=1.41.1", "opentelemetry-sdk>=1.27", "opentelemetry-instrumentation-fastapi>=0.63b1", "opentelemetry-instrumentation-httpx>=0.63b1", "opentelemetry-exporter-otlp-proto-http>=1.42.0", "opentelemetry-semantic-conventions>=0.49b0", "langfuse>=4.6.1", "arize-phoenix-otel>=0.16.1"]
+all = ["anthropic>=0.105.2", "openai>=2.41.0", "google-generativeai>=0.8.6", "asyncpg>=0.31.0", "fastapi>=0.115", "uvicorn[standard]>=0.49.0", "websockets>=16.0", "httpx>=0.28.1", "authlib>=1.7.2", "PyJWT>=2.13.0", "itsdangerous>=2.2.0", "bcrypt>=5.0.0", "python-multipart>=0.0.31", "cryptography>=48.0.0", "pytesseract>=0.3.13", "Pillow>=10.0", "opentelemetry-api>=1.42.1", "opentelemetry-sdk>=1.42.1", "opentelemetry-instrumentation-fastapi>=0.63b1", "opentelemetry-instrumentation-httpx>=0.63b1", "opentelemetry-exporter-otlp-proto-http>=1.42.0", "opentelemetry-semantic-conventions>=0.63b1", "langfuse>=4.7.1", "arize-phoenix-otel>=0.16.1"]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.4.0",


### PR DESCRIPTION
Combines the 5 remaining individual Dependabot pip PRs into one to avoid the per-package `pyproject.toml` conflict cascade.

| Package | From | To | Supersedes |
|---|---|---|---|
| pytesseract | >=0.3.10 | >=0.3.13 | #154 |
| opentelemetry-api | >=1.41.1 | >=1.42.1 | #156 |
| opentelemetry-sdk | >=1.27 | >=1.42.1 | #161 |
| opentelemetry-semantic-conventions | >=0.49b0 | >=0.63b1 | #157 |
| langfuse | >=4.6.1 | >=4.7.1 | #158 |

Closes #154, #156, #157, #158, #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)