### PR TITLE
feat(agent-host): live token meter + fix confirmation-prompt WS drop

### DIFF
--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -38,7 +38,8 @@ use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
 
 use super::protocol::{
-    parse_frame_str, Frame, Hello, Prompt, Step, ToolCall, ToolChunk, ToolResult, PROTOCOL_VERSION,
+    parse_frame_str, Frame, Hello, Prompt, Step, ToolCall, ToolChunk, ToolResult, TurnEnd,
+    PROTOCOL_VERSION,
 };
 use super::runner::{CancelSignal, ChunkEmitter, LocalToolRunner, ShellConfirmer, ToolOutcome};
 use super::signing::{compute_signature, decode_hex_key};
@@ -336,6 +337,9 @@ async fn receive_loop(
     cancels: Arc<Mutex<HashMap<String, CancelSignal>>>,
 ) {
     let theme = AnsiTheme::detect();
+    // Live token-meter state, reset per turn so tok/s reflects the
+    // current turn rather than the whole session.
+    let mut meter = Meter::new();
     loop {
         let frame_res = {
             let mut s = stream.lock().await;
@@ -378,8 +382,12 @@ async fn receive_loop(
                 print!("{}", t.chunk);
                 let _ = std::io::stdout().flush();
             }
-            Frame::TurnEnd(_) => {
+            Frame::TurnEnd(t) => {
+                // End the assistant text on stdout, then a usage summary
+                // on stderr so a piped stdout stays clean.
                 println!();
+                print_turn_end(&theme, &t);
+                meter.reset();
             }
             Frame::Error(e) => {
                 eprintln!(
@@ -410,7 +418,7 @@ async fn receive_loop(
                 }
             }
             Frame::Step(s) => {
-                print_step(&theme, &s);
+                print_step(&theme, &s, &mut meter);
             }
             _ => {}
         }
@@ -618,10 +626,69 @@ impl AnsiTheme {
     }
 }
 
-fn print_step(theme: &AnsiTheme, step: &Step) {
+/// Live token-meter state for the current turn. `tok/s` is the
+/// downstream (output) rate between consecutive Step frames, falling
+/// back to the turn average on the first frame so the field is never
+/// blank.
+struct Meter {
+    turn_start: Instant,
+    last_t: Instant,
+    last_out: u64,
+}
+
+impl Meter {
+    fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            turn_start: now,
+            last_t: now,
+            last_out: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        let now = Instant::now();
+        self.turn_start = now;
+        self.last_t = now;
+        self.last_out = 0;
+    }
+
+    /// Record the latest cumulative output-token count and return the
+    /// instantaneous tok/s since the previous sample.
+    fn tok_per_s(&mut self, output_tokens: u64) -> f64 {
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_t).as_secs_f64();
+        let rate = if dt > 0.05 && output_tokens >= self.last_out {
+            (output_tokens - self.last_out) as f64 / dt
+        } else {
+            let elapsed = now.duration_since(self.turn_start).as_secs_f64();
+            if elapsed > 0.0 {
+                output_tokens as f64 / elapsed
+            } else {
+                0.0
+            }
+        };
+        self.last_t = now;
+        self.last_out = output_tokens;
+        rate
+    }
+}
+
+/// Compact token count: `950`, `12.3k`, `1.5M`.
+fn fmt_tokens(n: u64) -> String {
+    if n < 1000 {
+        n.to_string()
+    } else if n < 1_000_000 {
+        format!("{:.1}k", n as f64 / 1000.0)
+    } else {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    }
+}
+
+fn print_step(theme: &AnsiTheme, step: &Step, meter: &mut Meter) {
     // Format examples:
-    //   "  [3/15] backend: writing api/main.py"
-    //   "  [2] team-lead: planning"        (total unknown)
+    //   "  [3/15] backend: writing api/main.py   ↑12.3k ↓4.5k · $0.0123 · 78 tok/s"
+    //   "  [2] team-lead: planning"        (total unknown, no usage yet)
     //   "  [-] team-lead: thinking"        (no index either — rare)
     let progress = if step.total > 0 {
         format!("[{}/{}]", step.index, step.total)
@@ -635,13 +702,60 @@ fn print_step(theme: &AnsiTheme, step: &Step) {
     } else {
         format!(" {}:", step.agent)
     };
+    let meter_str = if step.input_tokens > 0 || step.output_tokens > 0 {
+        let tok_s = meter.tok_per_s(step.output_tokens);
+        let cost = if step.cost_usd > 0.0 {
+            format!(" · ${:.4}", step.cost_usd)
+        } else {
+            String::new()
+        };
+        format!(
+            "  ↑{up} ↓{down}{cost} · {tps:.0} tok/s",
+            up = fmt_tokens(step.input_tokens),
+            down = fmt_tokens(step.output_tokens),
+            cost = cost,
+            tps = tok_s,
+        )
+    } else {
+        String::new()
+    };
     eprintln!(
-        "{dim}  {progress}{agent} {label}{reset}",
+        "{dim}  {progress}{agent} {label}{meter}{reset}",
         dim = theme.dim,
         reset = theme.reset,
         progress = progress,
         agent = agent,
         label = step.label,
+        meter = meter_str,
+    );
+}
+
+fn print_turn_end(theme: &AnsiTheme, turn: &TurnEnd) {
+    let mark = if turn.status == "ok" {
+        format!("{}✓{}", theme.green, theme.reset)
+    } else {
+        format!("{}✗{}", theme.red, theme.reset)
+    };
+    let mut bits = vec![format!("turn {}", turn.status)];
+    if turn.step_count > 0 {
+        bits.push(format!("{} steps", turn.step_count));
+    }
+    if turn.input_tokens > 0 || turn.output_tokens > 0 {
+        bits.push(format!(
+            "↑{} ↓{}",
+            fmt_tokens(turn.input_tokens),
+            fmt_tokens(turn.output_tokens)
+        ));
+    }
+    if turn.cost_usd > 0.0 {
+        bits.push(format!("${:.4}", turn.cost_usd));
+    }
+    eprintln!(
+        "  {mark} {dim}{body}{reset}",
+        mark = mark,
+        dim = theme.dim,
+        reset = theme.reset,
+        body = bits.join(" · "),
     );
 }
 
@@ -883,6 +997,27 @@ mod tests {
         let s = summarise_args(&m);
         assert!(s.contains("file_path=note.md"));
         assert!(s.contains("content=<2048B>"));
+    }
+
+    #[test]
+    fn fmt_tokens_compacts() {
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(950), "950");
+        assert_eq!(fmt_tokens(12_345), "12.3k");
+        assert_eq!(fmt_tokens(1_500_000), "1.5M");
+    }
+
+    #[test]
+    fn meter_tok_per_s_is_non_negative_and_resets() {
+        let mut m = Meter::new();
+        // First sample falls back to the turn average — never negative.
+        let r1 = m.tok_per_s(100);
+        assert!(r1 >= 0.0);
+        // A non-increasing count must not produce a negative rate.
+        let r2 = m.tok_per_s(100);
+        assert!(r2 >= 0.0);
+        m.reset();
+        assert_eq!(m.last_out, 0);
     }
 
     #[test]

--- a/cli/src/agent_host/protocol.rs
+++ b/cli/src/agent_host/protocol.rs
@@ -325,6 +325,15 @@ pub struct TurnEnd {
     pub status: String,
     #[serde(default)]
     pub step_count: u64,
+    /// Turn totals — upstream prompt tokens, downstream completion
+    /// tokens, accumulated USD cost. Additive: a server that does not
+    /// send them leaves these 0 (`#[serde(default)]`).
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// Server → client. Progress indicator inside a turn — see
@@ -347,6 +356,15 @@ pub struct Step {
     pub label: String,
     #[serde(default)]
     pub agent: String,
+    /// Cumulative turn totals known when this step was emitted — turns
+    /// the progress line into a live token meter. Additive: a server
+    /// that does not send them leaves these 0 (`#[serde(default)]`).
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// The wire kind is `error` but Rust reserves `Error` so we suffix.
@@ -560,6 +578,61 @@ mod tests {
         let parsed = parse_frame(&v).unwrap();
         if let Frame::Hello(h) = parsed {
             assert_eq!(h.version, 99);
+        } else {
+            panic!("kind drift");
+        }
+    }
+
+    #[test]
+    fn step_round_trip_with_usage() {
+        let f = Frame::Step(Step {
+            kind: KIND_STEP.into(),
+            frame_id: "f".into(),
+            timestamp: 0.0,
+            index: 3,
+            total: 0,
+            label: "thinking".into(),
+            agent: "team-lead".into(),
+            input_tokens: 4096,
+            output_tokens: 512,
+            cost_usd: 0.004,
+        });
+        assert_eq!(round_trip(f.clone()), f);
+    }
+
+    #[test]
+    fn turn_end_round_trip_with_usage() {
+        let f = Frame::TurnEnd(TurnEnd {
+            kind: KIND_TURN_END.into(),
+            frame_id: "f".into(),
+            timestamp: 0.0,
+            status: "ok".into(),
+            step_count: 7,
+            input_tokens: 1234,
+            output_tokens: 567,
+            cost_usd: 0.0123,
+        });
+        assert_eq!(round_trip(f.clone()), f);
+    }
+
+    #[test]
+    fn old_step_without_usage_defaults_to_zero() {
+        // A v1 server emits Step without the token meter fields — a new
+        // client must still parse it, defaulting them to 0.
+        let v = json!({
+            "kind": KIND_STEP,
+            "frame_id": "f",
+            "timestamp": 0.0,
+            "index": 1,
+            "total": 0,
+            "label": "x",
+            "agent": "",
+        });
+        let parsed = parse_frame(&v).expect("backward-compat parse");
+        if let Frame::Step(s) = parsed {
+            assert_eq!(s.input_tokens, 0);
+            assert_eq!(s.output_tokens, 0);
+            assert_eq!(s.cost_usd, 0.0);
         } else {
             panic!("kind drift");
         }

--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -54,12 +54,26 @@ documented in
    - Mints `tool_call_id` + `nonce`.
    - HMAC-SHA-256 of `(run_id, tool_call_id, nonce, name)` using
      `JWT_SECRET_KEY` becomes the `signature`.
-   - Sends `TOOL_CALL`, awaits the matching `TOOL_RESULT` (60 s TTL).
+   - Sends `TOOL_CALL`, awaits the matching `TOOL_RESULT` (TTL = 5 min
+     default, see [Tuning the tool TTL](#tuning-the-tool-ttl)).
 6. Client verifies the HMAC, executes the tool, streams stdout in
    `TOOL_CHUNK` frames (for `shell_exec`), and finalises with a
    `TOOL_RESULT` signed with the same nonce.
-7. Agent loop continues. Final reply is streamed to the client as
-   `ASSISTANT_TEXT` chunks, terminated by `TURN_END`.
+7. Agent loop continues. Every orchestrator step also emits a `STEP`
+   frame carrying the **cumulative token meter** for the turn
+   (`input_tokens` upstream / `output_tokens` downstream / `cost_usd`),
+   so the client can render a live `↑12.3k ↓4.5k · $0.0123 · 78 tok/s`
+   status line instead of going silent. Final reply is streamed to the
+   client as `ASSISTANT_TEXT` chunks, terminated by `TURN_END` — which
+   carries the turn totals (`step_count`, `input_tokens`,
+   `output_tokens`, `cost_usd`) for a closing summary.
+
+   The token fields are additive: a v1 client that ignores them keeps
+   working (`Frame.from_dict` drops unknown fields and defaults missing
+   ones to 0). The server fills them from the `TOKEN_UPDATE` events that
+   `run_agent` emits after each step — see
+   [`dashboard/cli_routes.py`](../src/agent_orchestrator/dashboard/cli_routes.py)
+   `forward_steps`.
 
 ## Security model
 
@@ -139,6 +153,36 @@ WS handshakes — no env var to flip.
 Remove the `agent_host_endpoint` route registration in
 `cli_routes.py` (or guard it behind an env flag in a downstream
 override).  The protocol module remains harmless on its own.
+
+### Tuning the tool TTL
+
+When the server proxies a `TOOL_CALL`, the clock until the matching
+`TOOL_RESULT` starts immediately — and that window **includes any
+interactive confirmation the client shows the user** (e.g.
+``allow `ls`? [y/N]``). The original 60 s TTL was shorter than a human
+typically takes to read and answer such a prompt, so the call timed out
+mid-confirmation and the connection was torn down with a `Broken pipe` /
+`peer closed connection without sending TLS close_notify` error on the
+client.
+
+The default is now **300 s (5 min)** and overridable:
+
+```bash
+# Give users longer to answer confirmation prompts (seconds)
+export AGENT_HOST_TOOL_TTL_SECONDS=600
+```
+
+Invalid or non-positive values fall back to the default (logged at
+WARNING). See `_tool_ttl_from_env` in
+[`agent_host/server.py`](../src/agent_orchestrator/agent_host/server.py)
+and `TestToolTTLConfig` in
+[`tests/test_agent_host_server.py`](../tests/test_agent_host_server.py).
+
+> **Native client note.** The Rust `ago` binary should also avoid
+> blocking the WS read loop while it waits on stdin for a confirmation,
+> and may render the new `STEP`/`TURN_END` token fields. Those are
+> client-side changes that live in the `ago` repo; the server fix above
+> already prevents the timeout regardless of client.
 
 ### Debugging a stuck session
 

--- a/docs/agent-host.md
+++ b/docs/agent-host.md
@@ -178,11 +178,14 @@ WARNING). See `_tool_ttl_from_env` in
 and `TestToolTTLConfig` in
 [`tests/test_agent_host_server.py`](../tests/test_agent_host_server.py).
 
-> **Native client note.** The Rust `ago` binary should also avoid
-> blocking the WS read loop while it waits on stdin for a confirmation,
-> and may render the new `STEP`/`TURN_END` token fields. Those are
-> client-side changes that live in the `ago` repo; the server fix above
-> already prevents the timeout regardless of client.
+> **Native client.** The Rust `ago` binary lives in [`cli/`](../cli).
+> It renders the token meter from the new `STEP`/`TURN_END` fields
+> ([`cli/src/agent_host/client.rs`](../cli/src/agent_host/client.rs)
+> `print_step` / `print_turn_end` / `Meter`) and already runs the
+> interactive shell confirmation on a blocking thread
+> (`StdinShellConfirmer` → `tokio::task::spawn_blocking`), so answering
+> `[y/N]` never stalls the WS read loop. The server TTL fix above is the
+> belt-and-braces guard that prevents the timeout regardless of client.
 
 ### Debugging a stuck session
 

--- a/docs/managing-local-projects.md
+++ b/docs/managing-local-projects.md
@@ -132,6 +132,29 @@ handshake succeeds:
 > _
 ```
 
+### Live token meter
+
+During a turn the REPL no longer goes silent between steps. Each
+orchestrator step prints a dim status line with a **live token meter** —
+upstream (prompt) vs downstream (completion) tokens, accumulated cost,
+and current throughput — and the turn closes with a summary:
+
+```
+> Read README.md and write a summary into NOTES.md
+  [1] team-lead: planning            ↑1.2k ↓340 · $0.0021 · 88 tok/s
+  ↳ file_read(path=README.md)
+  ✓ file_read in 4ms — 1 file
+  [2] backend: writing NOTES.md      ↑3.4k ↓910 · $0.0061 · 132 tok/s
+  ↳ file_write(path=NOTES.md)
+  ✓ file_write in 6ms — 1 file
+  ✓ turn ok · 2 steps · ↑3.4k ↓910 · $0.0061
+```
+
+The meter is read from the `STEP` / `TURN_END` frames (fields
+`input_tokens` / `output_tokens` / `cost_usd`); `tok/s` is computed
+client-side. It renders on **stderr**, so piping stdout to a file
+(`ago run --client-tools "…" > out.md`) keeps the artefact clean.
+
 ---
 
 ## Security defaults (do not weaken without thought)
@@ -161,7 +184,10 @@ The CLI side enforces three guards before any tool runs:
 
 Resource bounds the server enforces:
 
-- 60 s TTL per delegated tool call (configurable in the registry).
+- 5 min TTL per delegated tool call — long enough to answer an
+  interactive confirmation without the connection dropping. Override with
+  `AGENT_HOST_TOOL_TTL_SECONDS` on the dashboard. (Was 60 s, which timed
+  out mid-confirmation; see Troubleshooting below.)
 - 10 MB per call output cap, 4 concurrent streams per run.
 - `--mode prompt` is ignored when `--client-tools` is set — the agent
   loop is always on for client-side delegation to make sense.
@@ -177,7 +203,8 @@ Resource bounds the server enforces:
 | `agent-host requires the websockets package` | Python harness not installed | `pip install agent-orchestrator` or `AGO_PYTHON=…` |
 | `path_outside_workspace` in agent output | Agent tried to write outside cwd | Run `ago` from a higher directory, or set `cwd` argument when spawning |
 | `shell_denied` | Non-interactive call to a new binary | Re-run in an interactive shell to confirm, or pre-populate the allow file |
-| `tool_timeout` | The local tool exceeded 60 s | Split into smaller calls, or raise the registry TTL in the dashboard config |
+| `peer closed connection` / `Broken pipe` while answering `allow … [y/N]` | You took longer than the tool TTL to confirm; the server timed out the call and the WS dropped | Fixed: the default TTL is now 5 min. Confirm promptly, or raise `AGENT_HOST_TOOL_TTL_SECONDS` on the dashboard |
+| `tool_timeout` | The local tool exceeded the TTL (default 5 min) | Split into smaller calls, or raise `AGENT_HOST_TOOL_TTL_SECONDS` |
 | Subprocess hangs on Ctrl-C | First Ctrl-C is the REPL's empty-line; second exits | press it twice |
 
 Per-feature deep dives:

--- a/docs/website/static/feature-map.json
+++ b/docs/website/static/feature-map.json
@@ -29,8 +29,8 @@
       "classes": [],
       "in_degree": 3,
       "out_degree": 14,
-      "lines": 1484,
-      "weight": 10.17
+      "lines": 1504,
+      "weight": 10.18
     },
     {
       "id": "dashboard.agent_runtime_router",
@@ -145,8 +145,8 @@
       "classes": [],
       "in_degree": 1,
       "out_degree": 7,
-      "lines": 625,
-      "weight": 5.8
+      "lines": 694,
+      "weight": 5.84
     },
     {
       "id": "dashboard.evals_routes",
@@ -255,8 +255,8 @@
       "classes": [],
       "in_degree": 2,
       "out_degree": 2,
-      "lines": 507,
-      "weight": 7.71
+      "lines": 521,
+      "weight": 7.72
     },
     {
       "id": "dashboard.personalized_memory_routes",
@@ -420,7 +420,7 @@
       ],
       "in_degree": 3,
       "out_degree": 10,
-      "lines": 486,
+      "lines": 488,
       "weight": 14.69
     },
     {
@@ -2001,7 +2001,31 @@
   "edges": [
     {
       "source": "core.agent",
+      "target": "core.tracing"
+    },
+    {
+      "source": "core.agent",
+      "target": "core.tool_recovery"
+    },
+    {
+      "source": "core.agent",
       "target": "core.metrics"
+    },
+    {
+      "source": "core.agent",
+      "target": "core.prompt_markers"
+    },
+    {
+      "source": "core.agent",
+      "target": "core.provider"
+    },
+    {
+      "source": "core.agent",
+      "target": "core.clarification"
+    },
+    {
+      "source": "core.agent",
+      "target": "core.personalized_memory"
     },
     {
       "source": "core.agent",
@@ -2013,31 +2037,7 @@
     },
     {
       "source": "core.agent",
-      "target": "core.tracing"
-    },
-    {
-      "source": "core.agent",
-      "target": "core.clarification"
-    },
-    {
-      "source": "core.agent",
-      "target": "core.tool_recovery"
-    },
-    {
-      "source": "core.agent",
       "target": "core.skill"
-    },
-    {
-      "source": "core.agent",
-      "target": "core.prompt_markers"
-    },
-    {
-      "source": "core.agent",
-      "target": "core.personalized_memory"
-    },
-    {
-      "source": "core.agent",
-      "target": "core.provider"
     },
     {
       "source": "core.benchmark",
@@ -2061,11 +2061,11 @@
     },
     {
       "source": "core.conversation",
-      "target": "core.checkpoint"
+      "target": "core.memory_filter"
     },
     {
       "source": "core.conversation",
-      "target": "core.metrics"
+      "target": "core.checkpoint"
     },
     {
       "source": "core.conversation",
@@ -2073,7 +2073,7 @@
     },
     {
       "source": "core.conversation",
-      "target": "core.memory_filter"
+      "target": "core.metrics"
     },
     {
       "source": "core.cooperation",
@@ -2113,15 +2113,15 @@
     },
     {
       "source": "core.graph_templates",
-      "target": "core.graph_patterns"
-    },
-    {
-      "source": "core.graph_templates",
       "target": "core.llm_nodes"
     },
     {
       "source": "core.graph_templates",
       "target": "core.graph"
+    },
+    {
+      "source": "core.graph_templates",
+      "target": "core.graph_patterns"
     },
     {
       "source": "core.graph_templates",
@@ -2133,18 +2133,6 @@
     },
     {
       "source": "core.knowledge",
-      "target": "core.knowledge.store"
-    },
-    {
-      "source": "core.knowledge",
-      "target": "core.knowledge.chunker"
-    },
-    {
-      "source": "core.knowledge",
-      "target": "core.knowledge.embeddings"
-    },
-    {
-      "source": "core.knowledge",
       "target": "core.knowledge.ingestion"
     },
     {
@@ -2152,16 +2140,28 @@
       "target": "core.knowledge.retrieval"
     },
     {
+      "source": "core.knowledge",
+      "target": "core.knowledge.chunker"
+    },
+    {
+      "source": "core.knowledge",
+      "target": "core.knowledge.store"
+    },
+    {
+      "source": "core.knowledge",
+      "target": "core.knowledge.embeddings"
+    },
+    {
       "source": "core.knowledge.ingestion",
       "target": "core.knowledge.chunker"
     },
     {
       "source": "core.knowledge.ingestion",
-      "target": "core.knowledge.embeddings"
+      "target": "core.knowledge.store"
     },
     {
       "source": "core.knowledge.ingestion",
-      "target": "core.knowledge.store"
+      "target": "core.knowledge.embeddings"
     },
     {
       "source": "core.knowledge.retrieval",
@@ -2189,15 +2189,7 @@
     },
     {
       "source": "core.orchestrator",
-      "target": "core.agent"
-    },
-    {
-      "source": "core.orchestrator",
-      "target": "core.cooperation"
-    },
-    {
-      "source": "core.orchestrator",
-      "target": "core.skill"
+      "target": "core.mcp_server"
     },
     {
       "source": "core.orchestrator",
@@ -2205,19 +2197,27 @@
     },
     {
       "source": "core.orchestrator",
-      "target": "core.mcp_server"
+      "target": "core.cooperation"
     },
     {
       "source": "core.orchestrator",
       "target": "core.provider"
     },
     {
-      "source": "core.personalized_memory",
-      "target": "core.store"
+      "source": "core.orchestrator",
+      "target": "core.agent"
+    },
+    {
+      "source": "core.orchestrator",
+      "target": "core.skill"
     },
     {
       "source": "core.personalized_memory",
       "target": "core.memory_filter"
+    },
+    {
+      "source": "core.personalized_memory",
+      "target": "core.store"
     },
     {
       "source": "core.prompt_registry",
@@ -2245,19 +2245,19 @@
     },
     {
       "source": "core.skill",
-      "target": "core.mcp_client"
-    },
-    {
-      "source": "core.skill",
       "target": "core.cache"
     },
     {
-      "source": "core.store",
-      "target": "core.conformance"
+      "source": "core.skill",
+      "target": "core.mcp_client"
     },
     {
       "source": "core.store",
       "target": "core.memory_filter"
+    },
+    {
+      "source": "core.store",
+      "target": "core.conformance"
     },
     {
       "source": "core.store_postgres",
@@ -2277,7 +2277,7 @@
     },
     {
       "source": "core.verifiers",
-      "target": "core.verifiers.runtime_smoke"
+      "target": "core.verifiers.imports"
     },
     {
       "source": "core.verifiers",
@@ -2285,19 +2285,11 @@
     },
     {
       "source": "core.verifiers",
-      "target": "core.verifiers.imports"
+      "target": "core.verifiers.runtime_smoke"
     },
     {
       "source": "core.verifiers",
-      "target": "core.verifiers.coherence"
-    },
-    {
-      "source": "core.verifiers",
-      "target": "core.verifiers.entrypoint"
-    },
-    {
-      "source": "core.verifiers",
-      "target": "core.verifiers.dependency"
+      "target": "core.verifiers.syntax"
     },
     {
       "source": "core.verifiers",
@@ -2305,7 +2297,15 @@
     },
     {
       "source": "core.verifiers",
-      "target": "core.verifiers.syntax"
+      "target": "core.verifiers.dependency"
+    },
+    {
+      "source": "core.verifiers",
+      "target": "core.verifiers.entrypoint"
+    },
+    {
+      "source": "core.verifiers",
+      "target": "core.verifiers.coherence"
     },
     {
       "source": "core.verifiers.coherence",
@@ -2317,15 +2317,15 @@
     },
     {
       "source": "core.verifiers.e2e_smoke",
+      "target": "core.verifiers.entrypoint"
+    },
+    {
+      "source": "core.verifiers.e2e_smoke",
       "target": "core.verification_gate"
     },
     {
       "source": "core.verifiers.e2e_smoke",
       "target": "core.verifiers.runtime_smoke"
-    },
-    {
-      "source": "core.verifiers.e2e_smoke",
-      "target": "core.verifiers.entrypoint"
     },
     {
       "source": "core.verifiers.encoding",
@@ -2357,7 +2357,23 @@
     },
     {
       "source": "dashboard.agent_runner",
+      "target": "core.sandbox"
+    },
+    {
+      "source": "dashboard.agent_runner",
       "target": "core.conversation"
+    },
+    {
+      "source": "dashboard.agent_runner",
+      "target": "core.smoke_tester"
+    },
+    {
+      "source": "dashboard.agent_runner",
+      "target": "skills"
+    },
+    {
+      "source": "dashboard.agent_runner",
+      "target": "core.store"
     },
     {
       "source": "dashboard.agent_runner",
@@ -2369,7 +2385,7 @@
     },
     {
       "source": "dashboard.agent_runner",
-      "target": "skills"
+      "target": "core.provider"
     },
     {
       "source": "dashboard.agent_runner",
@@ -2377,31 +2393,7 @@
     },
     {
       "source": "dashboard.agent_runner",
-      "target": "dashboard.agents_registry"
-    },
-    {
-      "source": "dashboard.agent_runner",
       "target": "core.agent"
-    },
-    {
-      "source": "dashboard.agent_runner",
-      "target": "core.sandbox"
-    },
-    {
-      "source": "dashboard.agent_runner",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.agent_runner",
-      "target": "core.smoke_tester"
-    },
-    {
-      "source": "dashboard.agent_runner",
-      "target": "core.store"
-    },
-    {
-      "source": "dashboard.agent_runner",
-      "target": "core.skill"
     },
     {
       "source": "dashboard.agent_runner",
@@ -2409,11 +2401,15 @@
     },
     {
       "source": "dashboard.agent_runner",
-      "target": "core.provider"
+      "target": "dashboard.agents_registry"
     },
     {
-      "source": "dashboard.agent_runtime_router",
-      "target": "core.cache_context"
+      "source": "dashboard.agent_runner",
+      "target": "dashboard.events"
+    },
+    {
+      "source": "dashboard.agent_runner",
+      "target": "core.skill"
     },
     {
       "source": "dashboard.agent_runtime_router",
@@ -2421,19 +2417,31 @@
     },
     {
       "source": "dashboard.agent_runtime_router",
-      "target": "dashboard.graphs"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
-      "target": "core.failure_patterns"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
       "target": "skills.retrieval_skill"
     },
     {
       "source": "dashboard.agent_runtime_router",
-      "target": "dashboard.agents_registry"
+      "target": "dashboard.agent_runner"
+    },
+    {
+      "source": "dashboard.agent_runtime_router",
+      "target": "dashboard.events"
+    },
+    {
+      "source": "dashboard.agent_runtime_router",
+      "target": "providers.local"
+    },
+    {
+      "source": "dashboard.agent_runtime_router",
+      "target": "dashboard.auth"
+    },
+    {
+      "source": "dashboard.agent_runtime_router",
+      "target": "dashboard.graphs"
+    },
+    {
+      "source": "dashboard.agent_runtime_router",
+      "target": "core.verification_gate"
     },
     {
       "source": "dashboard.agent_runtime_router",
@@ -2445,131 +2453,19 @@
     },
     {
       "source": "dashboard.agent_runtime_router",
-      "target": "dashboard.auth"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
-      "target": "providers.local"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
-      "target": "dashboard.agent_runner"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
-      "target": "core.verification_gate"
-    },
-    {
-      "source": "dashboard.agent_runtime_router",
       "target": "providers.openrouter"
     },
     {
-      "source": "dashboard.app",
-      "target": "core.prompt_registry"
+      "source": "dashboard.agent_runtime_router",
+      "target": "core.cache_context"
     },
     {
-      "source": "dashboard.app",
-      "target": "dashboard.gateway_api"
+      "source": "dashboard.agent_runtime_router",
+      "target": "dashboard.agents_registry"
     },
     {
-      "source": "dashboard.app",
-      "target": "dashboard.sse"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.user_store"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.store_postgres"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.personalized_memory_routes"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.mcp_client"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.agent_runtime_router"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.knowledge_routes"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.cli_routes"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.auth"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.job_logger"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.usage_db"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.store"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.sandbox_manager"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.alert_webhook"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.conversation"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.cli_device_flow_postgres"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.oauth_routes"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.knowledge"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.personalized_memory"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.metrics"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "dashboard.evals_routes"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.checkpoint"
-    },
-    {
-      "source": "dashboard.app",
-      "target": "core.sandbox"
+      "source": "dashboard.agent_runtime_router",
+      "target": "core.failure_patterns"
     },
     {
       "source": "dashboard.app",
@@ -2577,11 +2473,115 @@
     },
     {
       "source": "dashboard.app",
+      "target": "dashboard.cli_routes"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.evals_routes"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.usage_db"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.knowledge"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.alert_webhook"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.gateway_api"
+    },
+    {
+      "source": "dashboard.app",
       "target": "dashboard.cli_device_flow"
     },
     {
       "source": "dashboard.app",
+      "target": "core.store"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.sse"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.job_logger"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.store_postgres"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.sandbox"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.conversation"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.knowledge_routes"
+    },
+    {
+      "source": "dashboard.app",
       "target": "core.memory_filter"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.checkpoint"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.sandbox_manager"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.personalized_memory"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.cli_device_flow_postgres"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.events"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.user_store"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.mcp_client"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.personalized_memory_routes"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.auth"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.oauth_routes"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.metrics"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "core.prompt_registry"
+    },
+    {
+      "source": "dashboard.app",
+      "target": "dashboard.agent_runtime_router"
     },
     {
       "source": "dashboard.cli_device_flow_postgres",
@@ -2589,15 +2589,7 @@
     },
     {
       "source": "dashboard.cli_routes",
-      "target": "core.cache_context"
-    },
-    {
-      "source": "dashboard.cli_routes",
-      "target": "dashboard.graphs"
-    },
-    {
-      "source": "dashboard.cli_routes",
-      "target": "dashboard.agents_registry"
+      "target": "dashboard.events"
     },
     {
       "source": "dashboard.cli_routes",
@@ -2605,15 +2597,23 @@
     },
     {
       "source": "dashboard.cli_routes",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.cli_routes",
       "target": "dashboard.cli_device_flow"
     },
     {
       "source": "dashboard.cli_routes",
+      "target": "dashboard.graphs"
+    },
+    {
+      "source": "dashboard.cli_routes",
       "target": "dashboard.agent_runner"
+    },
+    {
+      "source": "dashboard.cli_routes",
+      "target": "core.cache_context"
+    },
+    {
+      "source": "dashboard.cli_routes",
+      "target": "dashboard.agents_registry"
     },
     {
       "source": "dashboard.evals_routes",
@@ -2621,7 +2621,11 @@
     },
     {
       "source": "dashboard.gateway_api",
-      "target": "core.prompt_registry"
+      "target": "core.mcp_server"
+    },
+    {
+      "source": "dashboard.gateway_api",
+      "target": "core.mcp_client"
     },
     {
       "source": "dashboard.gateway_api",
@@ -2629,7 +2633,11 @@
     },
     {
       "source": "dashboard.gateway_api",
-      "target": "dashboard.graphs"
+      "target": "dashboard.tracing_metrics"
+    },
+    {
+      "source": "dashboard.gateway_api",
+      "target": "core.document_converter"
     },
     {
       "source": "dashboard.gateway_api",
@@ -2641,15 +2649,15 @@
     },
     {
       "source": "dashboard.gateway_api",
+      "target": "dashboard.graphs"
+    },
+    {
+      "source": "dashboard.gateway_api",
+      "target": "core.prompt_registry"
+    },
+    {
+      "source": "dashboard.gateway_api",
       "target": "dashboard.agents_registry"
-    },
-    {
-      "source": "dashboard.gateway_api",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.gateway_api",
-      "target": "core.document_converter"
     },
     {
       "source": "dashboard.gateway_api",
@@ -2657,19 +2665,11 @@
     },
     {
       "source": "dashboard.gateway_api",
-      "target": "core.mcp_client"
-    },
-    {
-      "source": "dashboard.gateway_api",
-      "target": "dashboard.tracing_metrics"
-    },
-    {
-      "source": "dashboard.gateway_api",
-      "target": "core.mcp_server"
-    },
-    {
-      "source": "dashboard.gateway_api",
       "target": "core.graph"
+    },
+    {
+      "source": "dashboard.gateway_api",
+      "target": "dashboard.events"
     },
     {
       "source": "dashboard.graphs",
@@ -2677,19 +2677,23 @@
     },
     {
       "source": "dashboard.graphs",
-      "target": "core.cache"
-    },
-    {
-      "source": "dashboard.graphs",
       "target": "core.llm_nodes"
     },
     {
       "source": "dashboard.graphs",
-      "target": "providers.openrouter"
+      "target": "core.cache"
     },
     {
       "source": "dashboard.graphs",
       "target": "core.provider"
+    },
+    {
+      "source": "dashboard.graphs",
+      "target": "core.graph"
+    },
+    {
+      "source": "dashboard.graphs",
+      "target": "providers.openrouter"
     },
     {
       "source": "dashboard.graphs",
@@ -2700,12 +2704,20 @@
       "target": "providers.local"
     },
     {
-      "source": "dashboard.graphs",
-      "target": "core.graph"
+      "source": "dashboard.instrument",
+      "target": "core.cooperation"
+    },
+    {
+      "source": "dashboard.instrument",
+      "target": "dashboard.tracing_metrics"
     },
     {
       "source": "dashboard.instrument",
       "target": "core.cache"
+    },
+    {
+      "source": "dashboard.instrument",
+      "target": "core.provider"
     },
     {
       "source": "dashboard.instrument",
@@ -2717,27 +2729,11 @@
     },
     {
       "source": "dashboard.instrument",
-      "target": "core.provider"
-    },
-    {
-      "source": "dashboard.instrument",
-      "target": "core.cooperation"
+      "target": "core.graph"
     },
     {
       "source": "dashboard.instrument",
       "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.instrument",
-      "target": "dashboard.tracing_metrics"
-    },
-    {
-      "source": "dashboard.instrument",
-      "target": "core.graph"
-    },
-    {
-      "source": "dashboard.knowledge_routes",
-      "target": "core.knowledge"
     },
     {
       "source": "dashboard.knowledge_routes",
@@ -2745,15 +2741,19 @@
     },
     {
       "source": "dashboard.knowledge_routes",
+      "target": "core.knowledge"
+    },
+    {
+      "source": "dashboard.knowledge_routes",
       "target": "dashboard.events"
     },
     {
       "source": "dashboard.oauth_routes",
-      "target": "dashboard.user_store"
+      "target": "dashboard.auth"
     },
     {
       "source": "dashboard.oauth_routes",
-      "target": "dashboard.auth"
+      "target": "dashboard.user_store"
     },
     {
       "source": "dashboard.sandbox_manager",
@@ -2765,11 +2765,59 @@
     },
     {
       "source": "dashboard.server",
+      "target": "core.checkpoint_postgres"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "dashboard.usage_db"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "dashboard.alert_webhook"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "core.tracing"
+    },
+    {
+      "source": "dashboard.server",
       "target": "dashboard.gateway_api"
     },
     {
       "source": "dashboard.server",
+      "target": "core.store"
+    },
+    {
+      "source": "dashboard.server",
       "target": "dashboard.sse"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "dashboard.job_logger"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "core.sandbox"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "core.conversation"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "core.memory_filter"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "core.checkpoint"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "dashboard.sandbox_manager"
+    },
+    {
+      "source": "dashboard.server",
+      "target": "dashboard.events"
     },
     {
       "source": "dashboard.server",
@@ -2781,47 +2829,7 @@
     },
     {
       "source": "dashboard.server",
-      "target": "dashboard.agent_runtime_router"
-    },
-    {
-      "source": "dashboard.server",
       "target": "dashboard.auth"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.job_logger"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.usage_db"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "core.store"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.sandbox_manager"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.alert_webhook"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "core.conversation"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.oauth_routes"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "dashboard.events"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "core.checkpoint"
     },
     {
       "source": "dashboard.server",
@@ -2829,27 +2837,19 @@
     },
     {
       "source": "dashboard.server",
-      "target": "core.tracing"
+      "target": "dashboard.oauth_routes"
     },
     {
       "source": "dashboard.server",
-      "target": "core.sandbox"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "core.checkpoint_postgres"
-    },
-    {
-      "source": "dashboard.server",
-      "target": "core.memory_filter"
-    },
-    {
-      "source": "dashboard.sse",
-      "target": "dashboard.events"
+      "target": "dashboard.agent_runtime_router"
     },
     {
       "source": "dashboard.sse",
       "target": "core.graph"
+    },
+    {
+      "source": "dashboard.sse",
+      "target": "dashboard.events"
     },
     {
       "source": "dashboard.user_store",
@@ -2857,11 +2857,11 @@
     },
     {
       "source": "integrations",
-      "target": "integrations.slack_bot"
+      "target": "integrations.telegram_bot"
     },
     {
       "source": "integrations",
-      "target": "integrations.telegram_bot"
+      "target": "integrations.slack_bot"
     },
     {
       "source": "providers",
@@ -2877,15 +2877,19 @@
     },
     {
       "source": "providers.local",
-      "target": "core.provider"
+      "target": "providers.openai"
     },
     {
       "source": "providers.local",
-      "target": "providers.openai"
+      "target": "core.provider"
     },
     {
       "source": "providers.openai",
       "target": "core.provider"
+    },
+    {
+      "source": "providers.openrouter",
+      "target": "providers.openai"
     },
     {
       "source": "providers.openrouter",
@@ -2896,20 +2900,12 @@
       "target": "core.provider"
     },
     {
-      "source": "providers.openrouter",
-      "target": "providers.openai"
-    },
-    {
       "source": "skills",
       "target": "skills.clarification_skill"
     },
     {
       "source": "skills",
-      "target": "skills.shell"
-    },
-    {
-      "source": "skills",
-      "target": "skills.doc_sync"
+      "target": "skills.sandboxed_shell"
     },
     {
       "source": "skills",
@@ -2917,7 +2913,11 @@
     },
     {
       "source": "skills",
-      "target": "skills.sandboxed_shell"
+      "target": "skills.doc_sync"
+    },
+    {
+      "source": "skills",
+      "target": "skills.shell"
     },
     {
       "source": "skills.clarification_skill",
@@ -2941,10 +2941,6 @@
     },
     {
       "source": "skills.profile_extractor_skill",
-      "target": "core.skill"
-    },
-    {
-      "source": "skills.profile_extractor_skill",
       "target": "core.personalized_memory"
     },
     {
@@ -2952,16 +2948,20 @@
       "target": "core.provider"
     },
     {
+      "source": "skills.profile_extractor_skill",
+      "target": "core.skill"
+    },
+    {
       "source": "skills.retrieval_skill",
       "target": "core.knowledge.store"
     },
     {
       "source": "skills.retrieval_skill",
-      "target": "core.skill"
+      "target": "core.knowledge"
     },
     {
       "source": "skills.retrieval_skill",
-      "target": "core.knowledge"
+      "target": "core.skill"
     },
     {
       "source": "skills.sandboxed_shell",
@@ -2977,11 +2977,11 @@
     },
     {
       "source": "skills.skill_loader",
-      "target": "core.skill"
+      "target": "core.metrics"
     },
     {
       "source": "skills.skill_loader",
-      "target": "core.metrics"
+      "target": "core.skill"
     },
     {
       "source": "skills.web_reader",

--- a/src/agent_orchestrator/agent_host/__main__.py
+++ b/src/agent_orchestrator/agent_host/__main__.py
@@ -39,6 +39,7 @@ def _fmt_tokens(n: int) -> str:
         return f"{n / 1000:.1f}k"
     return f"{n / 1_000_000:.1f}M"
 
+
 logger = logging.getLogger("agent_host.cli")
 
 

--- a/src/agent_orchestrator/agent_host/protocol.py
+++ b/src/agent_orchestrator/agent_host/protocol.py
@@ -263,12 +263,21 @@ class TurnEnd(Frame):
     turn (not a single tool call). ``step_count`` is how many agent steps
     the server ran for the turn — useful for budget reporting in the CLI
     REPL footer.
+
+    ``input_tokens`` / ``output_tokens`` / ``cost_usd`` are the turn
+    totals (upstream prompt tokens, downstream completion tokens, and the
+    accumulated USD cost). They let the client render a final usage
+    summary; additive fields, so a v1 client that ignores them keeps
+    working.
     """
 
     kind: ClassVar[str] = KIND_TURN_END
 
     status: str = "ok"
     step_count: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -303,6 +312,13 @@ class Step(Frame):
     ~80 chars. ``agent`` is the sub-agent name when team-lead has
     delegated, empty string when the top-level agent is doing the work
     itself.
+
+    ``input_tokens`` / ``output_tokens`` / ``cost_usd`` are the
+    *cumulative* turn totals known at the moment this step was emitted
+    (upstream prompt tokens, downstream completion tokens, accumulated
+    USD cost). They turn the per-step progress line into a live token
+    meter; additive fields, so a v1 client that ignores them keeps
+    working.
     """
 
     kind: ClassVar[str] = KIND_STEP
@@ -311,6 +327,9 @@ class Step(Frame):
     total: int = 0
     label: str = ""
     agent: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
 
 
 _KIND_MAP: dict[str, type[Frame]] = {

--- a/src/agent_orchestrator/agent_host/server.py
+++ b/src/agent_orchestrator/agent_host/server.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import secrets
 from typing import Any, Awaitable, Callable, Protocol
 
@@ -47,7 +48,41 @@ from .signing import compute_signature, new_nonce, new_session_key, verify_signa
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_TOOL_TTL_SECONDS = 60.0
+def _tool_ttl_from_env(default: float = 300.0) -> float:
+    """Resolve the per-tool result TTL (seconds) from the environment.
+
+    The TTL clock starts when the server sends a ``ToolCall`` and runs
+    until the client returns the matching ``ToolResult``. Crucially that
+    window includes any **human-in-the-loop confirmation** the client
+    shows (e.g. ``allow `ls`? [y/N]``). The old 60 s default was shorter
+    than a user typically takes to read and answer such a prompt, so the
+    call timed out mid-confirmation and the connection was torn down with
+    a ``Broken pipe`` / ``peer closed connection`` error. The default is
+    now generous (5 min) and overridable via
+    ``AGENT_HOST_TOOL_TTL_SECONDS`` so operators can tune it.
+    """
+    raw = os.environ.get("AGENT_HOST_TOOL_TTL_SECONDS")
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "agent-host: invalid AGENT_HOST_TOOL_TTL_SECONDS=%r, using %.0fs",
+            raw,
+            default,
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "agent-host: AGENT_HOST_TOOL_TTL_SECONDS must be > 0, using %.0fs",
+            default,
+        )
+        return default
+    return value
+
+
+DEFAULT_TOOL_TTL_SECONDS = _tool_ttl_from_env()
 HANDSHAKE_TIMEOUT_SECONDS = 10.0
 
 

--- a/src/agent_orchestrator/core/agent.py
+++ b/src/agent_orchestrator/core/agent.py
@@ -59,6 +59,8 @@ class TaskResult:
     artifacts: dict[str, Any] = field(default_factory=dict)
     steps_taken: int = 0
     total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
     total_cost_usd: float = 0.0
     error: str | None = None
     provider_used: str | None = None

--- a/src/agent_orchestrator/dashboard/agent_runner.py
+++ b/src/agent_orchestrator/dashboard/agent_runner.py
@@ -303,6 +303,8 @@ async def run_agent(
             data={
                 "total_tokens": result.total_tokens,
                 "agent_tokens": result.total_tokens,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
                 "agent_cost_usd": result.total_cost_usd,
             },
         )
@@ -315,6 +317,8 @@ async def run_agent(
         "output": result.output,
         "steps_taken": result.steps_taken,
         "total_tokens": result.total_tokens,
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
         "total_cost_usd": result.total_cost_usd,
         "elapsed_s": round(elapsed, 2),
         "error": result.error,
@@ -357,6 +361,8 @@ async def _instrumented_execute(
     retry_counts: dict[str, int] = {}
     total_cost = 0.0
     total_tokens = 0
+    total_input_tokens = 0
+    total_output_tokens = 0
     start_time = time.monotonic()
     files_created: list[str] = []
     step_log: list[str] = []
@@ -371,6 +377,8 @@ async def _instrumented_execute(
                 output="Agent timed out",
                 steps_taken=steps,
                 total_tokens=total_tokens,
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
                 total_cost_usd=total_cost,
                 error=f"Timeout after {elapsed:.0f}s",
                 artifacts={
@@ -424,11 +432,15 @@ async def _instrumented_execute(
         if hasattr(provider, "last_fallback_log") and provider.last_fallback_log:
             fallback_log.extend(provider.last_fallback_log)
 
+        total_input_tokens += completion.usage.input_tokens
+        total_output_tokens += completion.usage.output_tokens
         total_tokens += completion.usage.input_tokens + completion.usage.output_tokens
         total_cost += completion.usage.cost_usd
         steps += 1
 
-        # Emit incremental token/cost update after each step
+        # Emit incremental token/cost update after each step. The split
+        # (input/output) lets downstream consumers — the agent-host WS
+        # bridge in particular — render an upstream/downstream token meter.
         await event_bus.emit(
             Event(
                 event_type=EventType.TOKEN_UPDATE,
@@ -436,6 +448,8 @@ async def _instrumented_execute(
                 data={
                     "total_tokens": total_tokens,
                     "agent_tokens": total_tokens,
+                    "input_tokens": total_input_tokens,
+                    "output_tokens": total_output_tokens,
                     "agent_cost_usd": total_cost,
                 },
             )
@@ -454,6 +468,8 @@ async def _instrumented_execute(
                 output=completion.content,
                 steps_taken=steps,
                 total_tokens=total_tokens,
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
                 total_cost_usd=total_cost,
                 artifacts={
                     "files_created": files_created,
@@ -482,6 +498,8 @@ async def _instrumented_execute(
                     output=f"Stalled: too many retries on {tool_call.name}",
                     steps_taken=steps,
                     total_tokens=total_tokens,
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
                     total_cost_usd=total_cost,
                     error=f"Max retries exceeded for: {approach_key}",
                     artifacts={
@@ -576,6 +594,8 @@ async def _instrumented_execute(
         output="Agent reached max steps without completing",
         steps_taken=steps,
         total_tokens=total_tokens,
+        input_tokens=total_input_tokens,
+        output_tokens=total_output_tokens,
         total_cost_usd=total_cost,
         error=f"Max steps ({config.max_steps}) reached",
         artifacts={

--- a/src/agent_orchestrator/dashboard/cli_routes.py
+++ b/src/agent_orchestrator/dashboard/cli_routes.py
@@ -396,12 +396,15 @@ async def cli_run(body: dict, request: Request) -> StreamingResponse | JSONRespo
 
     try:
         ollama = _ollama_url()
-    except ValueError as exc:
-        return JSONResponse(content={"success": False, "error": "invalid OLLAMA_BASE_URL"}, status_code=400)
+    except ValueError:
+        return JSONResponse(
+            content={"success": False, "error": "invalid OLLAMA_BASE_URL"},
+            status_code=400,
+        )
     openrouter_key = os.environ.get("OPENROUTER_API_KEY", "")
     try:
         provider = _make_provider(model, provider_type, ollama, openrouter_key)
-    except Exception as exc:
+    except Exception:
         logger.exception("provider construction failed for %s/%s", model, provider_type)
         return JSONResponse(
             content={"success": False, "error": "provider error"},

--- a/tests/test_agent_host_protocol.py
+++ b/tests/test_agent_host_protocol.py
@@ -26,6 +26,7 @@ from agent_orchestrator.agent_host import (
     Hello,
     Prompt,
     SigningKeyMissingError,
+    Step,
     ToolCall,
     ToolChunk,
     ToolResult,
@@ -121,6 +122,33 @@ class TestFrameRoundTrip:
     def test_turn_end(self):
         self._round_trip(TurnEnd(status="ok", step_count=7))
 
+    def test_turn_end_with_usage(self):
+        self._round_trip(
+            TurnEnd(
+                status="ok",
+                step_count=7,
+                input_tokens=1234,
+                output_tokens=567,
+                cost_usd=0.0123,
+            )
+        )
+
+    def test_step(self):
+        self._round_trip(Step(index=2, total=15, label="writing main.py", agent="backend"))
+
+    def test_step_with_usage(self):
+        self._round_trip(
+            Step(
+                index=3,
+                total=0,
+                label="thinking",
+                agent="team-lead",
+                input_tokens=4096,
+                output_tokens=512,
+                cost_usd=0.004,
+            )
+        )
+
     def test_error(self):
         self._round_trip(Error(code="version_unsupported", message="v2 only"))
 
@@ -179,6 +207,27 @@ class TestParseFrame:
         parsed = parse_frame(raw)
         assert isinstance(parsed, ToolCall)
         assert parsed.name == "file_read"
+
+    def test_old_step_without_usage_defaults_to_zero(self):
+        """Backward compatibility: a v1 server emits Step without usage.
+
+        A new client must still parse it, defaulting the token meter
+        fields to 0 rather than raising.
+        """
+        raw = {
+            "kind": "step",
+            "frame_id": "f",
+            "timestamp": 0.0,
+            "index": 1,
+            "total": 0,
+            "label": "x",
+            "agent": "",
+        }
+        parsed = parse_frame(raw)
+        assert isinstance(parsed, Step)
+        assert parsed.input_tokens == 0
+        assert parsed.output_tokens == 0
+        assert parsed.cost_usd == 0.0
 
     def test_hello_version_carried_through(self):
         """The data layer does not validate ``version`` — that's the server's

--- a/tests/test_agent_host_server.py
+++ b/tests/test_agent_host_server.py
@@ -78,6 +78,45 @@ def signing_key(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Tool TTL configuration
+# ---------------------------------------------------------------------------
+
+
+class TestToolTTLConfig:
+    """The per-tool result TTL must be generous and env-tunable.
+
+    Regression guard: a 60 s TTL was shorter than a human takes to answer
+    an interactive ``allow `ls`? [y/N]`` confirmation, so the call timed
+    out mid-prompt and the connection dropped (``Broken pipe``).
+    """
+
+    def test_default_is_generous(self, monkeypatch):
+        from agent_orchestrator.agent_host import server
+
+        monkeypatch.delenv("AGENT_HOST_TOOL_TTL_SECONDS", raising=False)
+        # Default must comfortably exceed a human confirmation latency.
+        assert server._tool_ttl_from_env() >= 120.0
+
+    def test_env_override(self, monkeypatch):
+        from agent_orchestrator.agent_host import server
+
+        monkeypatch.setenv("AGENT_HOST_TOOL_TTL_SECONDS", "42.5")
+        assert server._tool_ttl_from_env() == 42.5
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        from agent_orchestrator.agent_host import server
+
+        monkeypatch.setenv("AGENT_HOST_TOOL_TTL_SECONDS", "not-a-number")
+        assert server._tool_ttl_from_env(default=99.0) == 99.0
+
+    def test_non_positive_env_falls_back(self, monkeypatch):
+        from agent_orchestrator.agent_host import server
+
+        monkeypatch.setenv("AGENT_HOST_TOOL_TTL_SECONDS", "0")
+        assert server._tool_ttl_from_env(default=99.0) == 99.0
+
+
+# ---------------------------------------------------------------------------
 # Handshake
 # ---------------------------------------------------------------------------
 

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -12,6 +12,7 @@ from agent_orchestrator.dashboard.agent_runner import (
     _parse_team_plan,
     _AGENT_ALIASES,
     _CATEGORY_FALLBACK_AGENTS,
+    run_agent,
     run_team,
 )
 from agent_orchestrator.dashboard.events import EventBus, EventType
@@ -875,3 +876,54 @@ class TestRunTeam:
             "quant-developer",
             "risk-analyst",
         }
+
+
+# ===== Token split (upstream/downstream meter) =====
+
+
+class TestTokenSplit:
+    """run_agent must surface input/output token split for the CLI meter.
+
+    The agent-host token meter (`↑input ↓output`) depends on these fields
+    being threaded out of the single-agent loop, both in the returned
+    envelope and in the per-step TOKEN_UPDATE events.
+    """
+
+    @pytest.mark.asyncio
+    async def test_return_envelope_carries_split(self):
+        # One completion (no tool calls) → one step with 10 in / 5 out.
+        provider = MockProvider(responses=["all done"])
+        result = await run_agent(
+            agent_name="backend",
+            task_description="do a thing",
+            provider=provider,
+            max_steps=3,
+        )
+        assert result["success"] is True
+        assert result["input_tokens"] == 10
+        assert result["output_tokens"] == 5
+        # Combined total stays consistent with the split.
+        assert result["total_tokens"] == result["input_tokens"] + result["output_tokens"]
+
+    @pytest.mark.asyncio
+    async def test_token_update_event_carries_split(self):
+        bus = EventBus()
+        sub = bus.subscribe()
+        provider = MockProvider(responses=["done"])
+        await run_agent(
+            agent_name="backend",
+            task_description="x",
+            provider=provider,
+            max_steps=2,
+            event_bus=bus,
+        )
+        # Drain the bus and look for a TOKEN_UPDATE that carries the split.
+        seen_split = False
+        while not sub.empty():
+            event = sub.get_nowait()
+            if event.event_type == EventType.TOKEN_UPDATE and isinstance(event.data, dict):
+                if "input_tokens" in event.data and "output_tokens" in event.data:
+                    assert event.data["input_tokens"] >= 0
+                    assert event.data["output_tokens"] >= 0
+                    seen_split = True
+        assert seen_split, "no TOKEN_UPDATE event carried the input/output split"

--- a/tests/test_cli_routes.py
+++ b/tests/test_cli_routes.py
@@ -263,4 +263,7 @@ def test_run_invalid_provider_returns_400(monkeypatch):
         json={"agent": "backend", "task": "x", "model": "m"},
     )
     assert resp.status_code == 400
-    assert "nope" in resp.text
+    # The raw exception message must NOT leak to the client; the handler
+    # returns a sanitized error and logs the traceback server-side.
+    assert "nope" not in resp.text
+    assert "provider error" in resp.text


### PR DESCRIPTION
## Why

Two feedback problems hit when using `ago chat --client-tools`:

1. **No token feedback** — the REPL went silent mid-turn. `STEP`/`TURN_END` frames carried no usage, and `TURN_END` wasn't even rendered.
2. **The WebSocket dropped during the `allow \`ls\`? [y/N]` confirmation.** The per-tool TTL clock (60s) includes the human think time, so an answer taking >60s timed out the call and tore down the connection (`Broken pipe` / `peer closed connection without sending TLS close_notify`). Reproduced from a real log: `✗ shell_exec in 80571ms — shell_denied`.

## What

- **protocol**: `Step` carries cumulative `input_tokens` / `output_tokens` / `cost_usd`; `TurnEnd` carries the turn totals. Additive fields — v1 clients ignore them (`from_dict` is tolerant).
- **agent_runner + core.agent**: track the input/output token split (only the combined total existed before); expose it on `TOKEN_UPDATE` events, `TaskResult`, and the `run_agent` return envelope.
- **cli_routes**: stamp live usage on every `Step` and the totals on `TurnEnd`.
- **agent_host REPL**: live meter `↑input ↓output · $cost · tok/s · [n/total]` per step + a turn summary on `TurnEnd`, on **stderr** so a piped stdout stays clean.
- **server**: per-tool TTL default **60s → 300s**, tunable via `AGENT_HOST_TOOL_TTL_SECONDS`, so human-in-the-loop confirmation no longer times out.

### Drive-by
The `codeql-autofix` change in `cli_run` sanitized provider errors (no longer leaks the raw exception) but left its test asserting the old message + two unused `exc` bindings (F841). Aligned the test to the sanitized response and removed the unused bindings.

## Tests & docs
- Tests: protocol roundtrip + backward-compat, TTL env parsing, token split in `run_agent`/events. **Full suite: 2461 passed, 10 skipped.**
- Docs: `docs/agent-host.md` (TTL tuning, token meter in the lifecycle) and `docs/managing-local-projects.md` (meter UX + troubleshooting the connection drop). Feature map regenerated.

## Note on the native client
The Rust `ago` client lives in its own repo. Rendering the new token fields and not blocking the WS read loop during confirmation are **follow-ups there** — but the server-side TTL fix already prevents the timeout regardless of client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)