### PR TITLE
feat(cli): client-side thrash guard + session diagnostics (ago v0.5.28→0.5.32)

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ago"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ago"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ago"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ago"
-version = "0.5.31"
+version = "0.5.32"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ago"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ago"
-version = "0.5.30"
+version = "0.5.31"
 edition = "2021"
 description = "Agent Orchestrator CLI — talk to a remote orchestrator from your local project."
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ago"
-version = "0.5.28"
+version = "0.5.29"
 edition = "2021"
 description = "Agent Orchestrator CLI — talk to a remote orchestrator from your local project."
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ago"
-version = "0.5.27"
+version = "0.5.28"
 edition = "2021"
 description = "Agent Orchestrator CLI — talk to a remote orchestrator from your local project."
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ago"
-version = "0.5.29"
+version = "0.5.30"
 edition = "2021"
 description = "Agent Orchestrator CLI — talk to a remote orchestrator from your local project."
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ago"
-version = "0.5.31"
+version = "0.5.32"
 edition = "2021"
 description = "Agent Orchestrator CLI — talk to a remote orchestrator from your local project."
 license = "MIT"

--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -646,8 +646,11 @@ async fn receive_loop(
             Frame::Step(s) => {
                 print_step(&theme, &s, &mut meter);
                 // Hard step/cost caps (opt-in). On trip, the guard halts the
-                // turn so subsequent tool calls are refused locally.
-                if let Some(msg) = guard.lock().await.on_step(s.index, s.cost_usd) {
+                // turn so subsequent tool calls are refused locally. Bind the
+                // result so the lock is released before the body (the tokio
+                // Mutex is not re-entrant).
+                let halt = guard.lock().await.on_step(s.index, s.cost_usd);
+                if let Some(msg) = halt {
                     eprintln!("{}{}{}", theme.red, msg, theme.reset);
                 }
             }
@@ -701,8 +704,10 @@ async fn handle_tool_call(
     // Thrash guard: if this exact call has been failing on repeat, or the turn
     // has been halted by a cap/breaker, refuse to run it and return a synthetic
     // error so no further local side effects happen and the server is nudged to
-    // change approach.
-    if let Decision::Block(reason) = guard.lock().await.before(&frame.name, &args_val) {
+    // change approach. Bind the decision so the lock is released before the body
+    // — the tokio Mutex is NOT re-entrant, and the body locks the guard again.
+    let decision = guard.lock().await.before(&frame.name, &args_val);
+    if let Decision::Block(reason) = decision {
         let outcome = ToolOutcome::err(&reason);
         print_progress_finished(&theme, &frame, &outcome, 0);
         guard.lock().await.after(&frame.name, &args_val, true);
@@ -758,13 +763,13 @@ async fn handle_tool_call(
     print_progress_finished(&theme, &frame, &outcome, elapsed_ms);
 
     // Record the outcome for the loop guard / failure breaker; print any notice
-    // (consecutive-failure warning or breaker halt) it raises.
-    if let Some(msg) =
-        guard
-            .lock()
-            .await
-            .after(&frame.name, &args_val, outcome.error_code.is_some())
-    {
+    // (consecutive-failure warning or breaker halt) it raises. Bind first so the
+    // lock is released before the body (non-re-entrant tokio Mutex).
+    let notice = guard
+        .lock()
+        .await
+        .after(&frame.name, &args_val, outcome.error_code.is_some());
+    if let Some(msg) = notice {
         eprintln!("{}{}{}", theme.red, msg, theme.reset);
     }
 

--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -237,6 +237,8 @@ pub async fn run_repl(
     shell_allow: &[String],
     shell_deny: &[String],
     shell_allow_all: bool,
+    // Resolved client-side thrash-guard config (default < .ago.yaml < env).
+    guard_config: GuardConfig,
     // Project instructions (AGO.md). The agent-host Prompt frame carries only
     // text, so we fold these into the FIRST prompt of the session — the server
     // keeps them in the conversation for the rest of the run.
@@ -254,8 +256,7 @@ pub async fn run_repl(
     // Client-side thrash guard at the tool-execution boundary (loop guard,
     // consecutive-failure breaker, hard step/cost caps). Shared across the
     // concurrently-spawned tool tasks and the step-frame handler.
-    let guard: Arc<Mutex<TurnGuard>> =
-        Arc::new(Mutex::new(TurnGuard::new(GuardConfig::from_env())));
+    let guard: Arc<Mutex<TurnGuard>> = Arc::new(Mutex::new(TurnGuard::new(guard_config)));
 
     // Split the WS into sink + stream so the receive loop can keep
     // reading while we send prompts and tool_results from another task.

--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -43,6 +43,7 @@ use super::protocol::{
 };
 use super::runner::{CancelSignal, ChunkEmitter, LocalToolRunner, ShellConfirmer, ToolOutcome};
 use super::signing::{compute_signature, decode_hex_key};
+use super::thrash_guard::{Decision, GuardConfig, TurnGuard};
 use tracing::debug;
 
 /// What the client learned during HELLO/ACK.
@@ -250,6 +251,11 @@ pub async fn run_repl(
     ));
     let session = Arc::new(session);
     let cancels: Arc<Mutex<HashMap<String, CancelSignal>>> = Arc::new(Mutex::new(HashMap::new()));
+    // Client-side thrash guard at the tool-execution boundary (loop guard,
+    // consecutive-failure breaker, hard step/cost caps). Shared across the
+    // concurrently-spawned tool tasks and the step-frame handler.
+    let guard: Arc<Mutex<TurnGuard>> =
+        Arc::new(Mutex::new(TurnGuard::new(GuardConfig::from_env())));
 
     // Split the WS into sink + stream so the receive loop can keep
     // reading while we send prompts and tool_results from another task.
@@ -273,6 +279,7 @@ pub async fn run_repl(
         session.clone(),
         runner.clone(),
         cancels.clone(),
+        guard.clone(),
         no_color,
     ));
 
@@ -499,6 +506,7 @@ async fn receive_loop(
     session: Arc<SessionInfo>,
     runner: Arc<LocalToolRunner>,
     cancels: Arc<Mutex<HashMap<String, CancelSignal>>>,
+    guard: Arc<Mutex<TurnGuard>>,
     no_color: bool,
 ) {
     let theme = AnsiTheme::detect(no_color);
@@ -595,6 +603,8 @@ async fn receive_loop(
                 let _ = std::io::stdout().flush();
                 print_turn_end(&theme, &t);
                 meter.reset();
+                // Per-turn thrash state is scoped to one turn.
+                guard.lock().await.reset();
             }
             Frame::Error(e) => {
                 // Flush whatever the assistant produced before the error so
@@ -621,8 +631,9 @@ async fn receive_loop(
                 let sink = sink.clone();
                 let cancels = cancels.clone();
                 let theme = theme.clone();
+                let guard = guard.clone();
                 tokio::spawn(async move {
-                    handle_tool_call(tc, session, runner, sink, cancels, theme).await;
+                    handle_tool_call(tc, session, runner, sink, cancels, guard, theme).await;
                 });
             }
             Frame::Cancel(c) => {
@@ -633,6 +644,11 @@ async fn receive_loop(
             }
             Frame::Step(s) => {
                 print_step(&theme, &s, &mut meter);
+                // Hard step/cost caps (opt-in). On trip, the guard halts the
+                // turn so subsequent tool calls are refused locally.
+                if let Some(msg) = guard.lock().await.on_step(s.index, s.cost_usd) {
+                    eprintln!("{}{}{}", theme.red, msg, theme.reset);
+                }
             }
             _ => {}
         }
@@ -645,6 +661,7 @@ async fn handle_tool_call(
     runner: Arc<LocalToolRunner>,
     sink: WsSink,
     cancels: Arc<Mutex<HashMap<String, CancelSignal>>>,
+    guard: Arc<Mutex<TurnGuard>>,
     theme: AnsiTheme,
 ) {
     let run_id = session.run_id.clone();
@@ -670,6 +687,32 @@ async fn handle_tool_call(
             &frame.name,
             key,
             &ToolOutcome::err("signature_invalid"),
+        )
+        .await;
+        return;
+    }
+
+    // Canonical (sorted-key) view of the args for the thrash guard's hash.
+    // `to_value` on a HashMap yields a BTreeMap-backed Object, so the hash is
+    // stable regardless of HashMap iteration order.
+    let args_val = serde_json::to_value(&frame.args).unwrap_or_default();
+
+    // Thrash guard: if this exact call has been failing on repeat, or the turn
+    // has been halted by a cap/breaker, refuse to run it and return a synthetic
+    // error so no further local side effects happen and the server is nudged to
+    // change approach.
+    if let Decision::Block(reason) = guard.lock().await.before(&frame.name, &args_val) {
+        let outcome = ToolOutcome::err(&reason);
+        print_progress_finished(&theme, &frame, &outcome, 0);
+        guard.lock().await.after(&frame.name, &args_val, true);
+        send_tool_result(
+            &sink,
+            &run_id,
+            &frame.tool_call_id,
+            &frame.nonce,
+            &frame.name,
+            key,
+            &outcome,
         )
         .await;
         return;
@@ -712,6 +755,17 @@ async fn handle_tool_call(
     let elapsed_ms = started.elapsed().as_millis() as u64;
 
     print_progress_finished(&theme, &frame, &outcome, elapsed_ms);
+
+    // Record the outcome for the loop guard / failure breaker; print any notice
+    // (consecutive-failure warning or breaker halt) it raises.
+    if let Some(msg) =
+        guard
+            .lock()
+            .await
+            .after(&frame.name, &args_val, outcome.error_code.is_some())
+    {
+        eprintln!("{}{}{}", theme.red, msg, theme.reset);
+    }
 
     {
         let mut map = cancels.lock().await;

--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -750,7 +750,7 @@ async fn handle_tool_call(
     };
 
     let started = Instant::now();
-    let outcome = runner
+    let mut outcome = runner
         .run(
             &frame.name,
             frame.args.clone(),
@@ -771,6 +771,25 @@ async fn handle_tool_call(
         .after(&frame.name, &args_val, outcome.error_code.is_some());
     if let Some(msg) = notice {
         eprintln!("{}{}{}", theme.red, msg, theme.reset);
+    }
+
+    // No-progress detection (feature B): if the same error *signature* (set by
+    // the runner's error digest) keeps recurring across attempts, inject a nudge
+    // into the result the agent sees, so it stops varying the command and fixes
+    // the unchanged root cause.
+    if let Some(sig) = outcome
+        .metadata
+        .get("error_signature")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+    {
+        let nudge = guard.lock().await.note_signature(&sig);
+        if let Some(msg) = nudge {
+            if let serde_json::Value::Object(map) = &mut outcome.output {
+                map.insert("guard_note".into(), serde_json::Value::String(msg.clone()));
+            }
+            eprintln!("{}{}{}", theme.red, msg, theme.reset);
+        }
     }
 
     {
@@ -991,12 +1010,55 @@ fn failure_reason(outcome: &ToolOutcome) -> String {
     }
 }
 
+/// One-line, log-safe summary of a tool call's args, so `--log-file` traces
+/// show *what* a step did — the command for `shell_exec`, the path for the file
+/// tools — not just the tool name. Without this the trace is "35 file_read, 24
+/// shell_exec" with no way to see which files or commands (the gap that made a
+/// stuck session impossible to diagnose from the log alone).
+fn summarize_args(name: &str, args: &HashMap<String, Value>) -> String {
+    match name {
+        "shell_exec" => {
+            if let Some(Value::Array(argv)) = args.get("argv") {
+                let cmd = argv
+                    .iter()
+                    .map(|v| {
+                        v.as_str()
+                            .map(str::to_string)
+                            .unwrap_or_else(|| v.to_string())
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                return compact_value(&Value::String(cmd));
+            }
+            match args.get("command").or_else(|| args.get("cmd")) {
+                Some(c) => compact_value(c),
+                None => "?".to_string(),
+            }
+        }
+        "file_read" | "file_write" => ["file_path", "path", "filepath"]
+            .iter()
+            .find_map(|k| args.get(*k))
+            .map(compact_value)
+            .unwrap_or_else(|| "?".to_string()),
+        _ => {
+            let mut keys: Vec<&str> = args.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            compact_value(&Value::String(keys.join(",")))
+        }
+    }
+}
+
 fn debug_frame(dir: &str, f: &Frame) {
     match f {
         Frame::Hello(h) => debug!("{dir} hello version={} agent={}", h.version, h.agent),
         Frame::Ack(a) => debug!("{dir} ack run_id={} model={}", a.run_id, a.model),
         Frame::Prompt(p) => debug!("{dir} prompt {}B", p.text.len()),
-        Frame::ToolCall(tc) => debug!("{dir} tool_call id={} name={}", tc.tool_call_id, tc.name),
+        Frame::ToolCall(tc) => debug!(
+            "{dir} tool_call id={} name={} args={}",
+            tc.tool_call_id,
+            tc.name,
+            summarize_args(&tc.name, &tc.args)
+        ),
         Frame::ToolResult(tr) => {
             if tr.status == "ok" {
                 debug!("{dir} tool_result id={} status=ok", tr.tool_call_id)
@@ -1573,6 +1635,38 @@ mod tests {
         assert_eq!(compact_value(&json!("a\nb")), "a b");
         let long = compact_value(&json!("x".repeat(500)));
         assert!(long.contains("…[+300 chars]"), "got {long}");
+    }
+
+    #[test]
+    fn summarize_args_shows_command_path_and_keys() {
+        let mut shell = HashMap::new();
+        shell.insert(
+            "argv".to_string(),
+            json!(["npm", "test", "--", "--watchAll=false"]),
+        );
+        assert_eq!(
+            summarize_args("shell_exec", &shell),
+            "npm test -- --watchAll=false"
+        );
+
+        let mut shell_str = HashMap::new();
+        shell_str.insert("command".to_string(), json!("pytest -q"));
+        assert_eq!(summarize_args("shell_exec", &shell_str), "pytest -q");
+
+        let mut path = HashMap::new();
+        path.insert("path".to_string(), json!("src/App.test.js"));
+        assert_eq!(summarize_args("file_read", &path), "src/App.test.js");
+        assert_eq!(summarize_args("file_write", &path), "src/App.test.js");
+
+        // Unknown tool → sorted key set, so the line is still informative.
+        let mut other = HashMap::new();
+        other.insert("zeta".to_string(), json!(1));
+        other.insert("alpha".to_string(), json!(2));
+        assert_eq!(summarize_args("mystery", &other), "alpha,zeta");
+
+        // Missing args never panic — they degrade to a marker.
+        assert_eq!(summarize_args("shell_exec", &HashMap::new()), "?");
+        assert_eq!(summarize_args("file_read", &HashMap::new()), "?");
     }
 
     #[test]

--- a/cli/src/agent_host/client.rs
+++ b/cli/src/agent_host/client.rs
@@ -1246,19 +1246,26 @@ fn print_progress_finished(
     }
 }
 
+/// Truncate `s` to at most `max` bytes on a UTF-8 char boundary, appending `…`
+/// if it was shortened. Plain byte slicing (`&s[..n]`) / `String::truncate`
+/// panic when `n` lands inside a multibyte char (e.g. `…`, `—`, `×`).
+fn truncate_ellipsis(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
+}
+
 fn summarise_args(args: &HashMap<String, Value>) -> String {
     let mut parts: Vec<String> = Vec::new();
     for (k, v) in args {
         let snippet = match v {
             Value::String(s) if k == "content" => format!("content=<{}B>", s.len()),
-            Value::String(s) => {
-                let mut sv = s.clone();
-                if sv.len() > 40 {
-                    sv.truncate(37);
-                    sv.push('…');
-                }
-                format!("{k}={sv}")
-            }
+            Value::String(s) => format!("{k}={}", truncate_ellipsis(s, 40)),
             Value::Array(arr) => {
                 let preview = arr
                     .iter()
@@ -1277,12 +1284,7 @@ fn summarise_args(args: &HashMap<String, Value>) -> String {
         };
         parts.push(snippet);
     }
-    let joined = parts.join(", ");
-    if joined.len() > 80 {
-        format!("{}…", &joined[..79])
-    } else {
-        joined
-    }
+    truncate_ellipsis(&parts.join(", "), 80)
 }
 
 fn summarise_output(output: &Value) -> String {
@@ -1318,12 +1320,7 @@ fn summarise_output(output: &Value) -> String {
     if let Value::String(s) = output {
         return human_bytes(s.len());
     }
-    let s = output.to_string();
-    if s.len() > 60 {
-        format!("{}…", &s[..57])
-    } else {
-        s
-    }
+    truncate_ellipsis(&output.to_string(), 57)
 }
 
 fn human_bytes(n: usize) -> String {
@@ -1401,6 +1398,25 @@ fn build_runner(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn truncate_ellipsis_is_char_boundary_safe() {
+        // Short strings pass through unchanged.
+        assert_eq!(truncate_ellipsis("hello", 40), "hello");
+        // ASCII over the limit truncates + ellipsis.
+        let long = "a".repeat(100);
+        let out = truncate_ellipsis(&long, 80);
+        assert!(out.ends_with('…') && out.len() <= 80 + '…'.len_utf8());
+        // Multibyte char straddling the cut must NOT panic, and the result is
+        // valid UTF-8 ending on a boundary (regression for the `&s[..n]` panic).
+        let s = format!("{}…{}", "x".repeat(78), "y".repeat(40)); // '…' spans bytes 78..81
+        let out = truncate_ellipsis(&s, 80);
+        assert!(out.is_char_boundary(out.len() - '…'.len_utf8()));
+        // summarise_args with a long unicode value does not panic.
+        let mut args = std::collections::HashMap::new();
+        args.insert("cmd".to_string(), json!(" — ".repeat(50)));
+        let _ = summarise_args(&args);
+    }
 
     #[test]
     fn derive_ws_url_https() {

--- a/cli/src/agent_host/error_digest.rs
+++ b/cli/src/agent_host/error_digest.rs
@@ -1,0 +1,301 @@
+//! Error-aware digest of a failing command's output (feature "A").
+//!
+//! When a `shell_exec` fails, its output is often large (a pytest run, a cargo
+//! build, a `docker compose` log). The context cap that folds the result back
+//! into the LLM keeps only a head+tail slice — which preserves the *summary*
+//! (`34 errors`) but elides the **middle**, where the actual diagnosis lives
+//! (the first traceback, the `OperationalError: …` line, the `error[E0599]`).
+//! The agent then sees *that* it failed but not *why*, and cannot converge.
+//!
+//! The CLI holds the full output before sending, so it can do better than blind
+//! head+tail: keep the head, the error-salient lines (with a line of context),
+//! and the tail. It also extracts a normalised **signature** of the dominant
+//! error so the thrash guard can detect "same failure, different command"
+//! (feature "B").
+
+/// Lower-cased substrings that mark a line as error-salient. Curated to catch
+/// the common toolchains (pytest, cargo/rustc, tsc, gcc, node, docker, psql)
+/// without matching every "warning". Only applied to *failed* commands.
+const ERROR_MARKERS: &[&str] = &[
+    "error",
+    "exception",
+    "traceback",
+    "panic",
+    "failed",
+    "assert",
+    "could not",
+    "cannot",
+    "no such",
+    "not found",
+    "refused",
+    "denied",
+    "fatal",
+    "undefined",
+    "unresolved",
+    "expected",
+];
+
+fn is_error_line(line: &str) -> bool {
+    let l = line.to_ascii_lowercase();
+    // pytest marks error/failure lines with a leading "E   ".
+    if line.trim_start().starts_with("E   ") || line.starts_with("E\t") {
+        return true;
+    }
+    ERROR_MARKERS.iter().any(|m| l.contains(m))
+}
+
+/// Join stdout + stderr for scanning. stderr first: most toolchains put the
+/// conclusive error there, and pytest's captured traceback still shows on stdout.
+fn combined(stdout: &str, stderr: &str) -> String {
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (false, false) => format!("{stdout}\n--- stderr ---\n{stderr}"),
+        (false, true) => stdout.to_string(),
+        (true, false) => stderr.to_string(),
+        (true, true) => String::new(),
+    }
+}
+
+/// Truncate `s` to ≤ `max` bytes on a char boundary, biased to keep `head_frac`
+/// of the budget at the start and the rest at the end (errors cluster at both
+/// the first failure and the final summary).
+fn clamp_head_tail(s: &str, max: usize, head_frac: f64) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let marker = "\n…\n";
+    let budget = max.saturating_sub(marker.len());
+    let head_len = (budget as f64 * head_frac) as usize;
+    let tail_len = budget - head_len;
+    let mut h = head_len;
+    while h > 0 && !s.is_char_boundary(h) {
+        h -= 1;
+    }
+    let mut t = s.len() - tail_len;
+    while t < s.len() && !s.is_char_boundary(t) {
+        t += 1;
+    }
+    format!("{}{}{}", &s[..h], marker, &s[t..])
+}
+
+/// Build a compact, error-focused excerpt of a failing command's output:
+/// head lines + error-salient lines (with one line of trailing context) + tail
+/// lines, gaps marked with `…`, the whole thing clamped to `max_bytes`.
+pub fn salient_excerpt(stdout: &str, stderr: &str, max_bytes: usize) -> String {
+    const HEAD: usize = 6;
+    const TAIL: usize = 12;
+    let text = combined(stdout, stderr);
+    let lines: Vec<&str> = text.lines().collect();
+    let n = lines.len();
+    if n == 0 {
+        return String::new();
+    }
+
+    let mut keep = vec![false; n];
+    for k in keep.iter_mut().take(HEAD.min(n)) {
+        *k = true;
+    }
+    for k in keep.iter_mut().skip(n.saturating_sub(TAIL)) {
+        *k = true;
+    }
+    for i in 0..n {
+        if is_error_line(lines[i]) {
+            keep[i] = true;
+            if i + 1 < n {
+                keep[i + 1] = true; // a line of context after the marker
+            }
+        }
+    }
+
+    let mut out = String::new();
+    let mut last: Option<usize> = None;
+    for (i, keep_it) in keep.iter().enumerate() {
+        if *keep_it {
+            if let Some(p) = last {
+                if i > p + 1 {
+                    out.push_str("…\n");
+                }
+            }
+            out.push_str(lines[i]);
+            out.push('\n');
+            last = Some(i);
+        }
+    }
+    clamp_head_tail(out.trim_end(), max_bytes, 0.4)
+}
+
+/// Substrings that mark a line as the *conclusive* error worth fingerprinting.
+const SIGNATURE_MARKERS: &[&str] = &[
+    "error:",
+    "error :",
+    "exception:",
+    "panicked",
+    "assertionerror",
+    "could not",
+    "no such",
+    "not found",
+    "refused",
+    "denied",
+    "fatal:",
+    "failed:",
+];
+
+/// Extract a normalised fingerprint of the dominant error, for no-progress
+/// detection. Returns `None` when nothing error-like is present. The *last*
+/// matching line wins: in a Python traceback the root exception is last, and
+/// compiler runs end on their summary error.
+pub fn error_signature(stdout: &str, stderr: &str) -> Option<String> {
+    let text = combined(stdout, stderr);
+    let mut candidate: Option<&str> = None;
+    for line in text.lines() {
+        let t = line.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let l = t.to_ascii_lowercase();
+        if SIGNATURE_MARKERS.iter().any(|m| l.contains(m)) {
+            candidate = Some(t);
+        }
+    }
+    candidate.map(normalize_signature)
+}
+
+/// Normalise a salient error line so the same root cause fingerprints
+/// identically across attempts: strip a leading pytest `E ` / `path:line:col:`
+/// prefix, collapse whitespace, drop volatile hex addresses, lower-case, cap.
+fn normalize_signature(line: &str) -> String {
+    let mut s = line.trim();
+    // Strip a leading pytest error prefix ("E   ").
+    if let Some(rest) = s.strip_prefix("E ") {
+        s = rest.trim_start();
+    }
+    // Strip a leading "path:line:col:" / "path:line:" location prefix.
+    let s = strip_location_prefix(s);
+    // Collapse whitespace, drop hex addresses, lower-case, cap length.
+    let collapsed: String = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let no_hex = drop_hex_addrs(&collapsed);
+    let mut out: String = no_hex.to_ascii_lowercase();
+    if out.len() > 160 {
+        let mut end = 160;
+        while end > 0 && !out.is_char_boundary(end) {
+            end -= 1;
+        }
+        out.truncate(end);
+    }
+    out
+}
+
+/// Drop a leading `path:NN:` or `path:NN:CC:` location prefix if present.
+fn strip_location_prefix(s: &str) -> &str {
+    // Find " error" / ": " split heuristically: if the head before the first
+    // space contains ":<digits>:", treat everything up to the last such colon
+    // group as a location prefix and strip it.
+    if let Some(first_space) = s.find(' ') {
+        let head = &s[..first_space];
+        if head.contains(':') && head.chars().any(|c| c.is_ascii_digit()) {
+            // e.g. "tests/test_auth.py:42:" → keep the rest after the prefix.
+            if let Some((_, rest)) = s.split_once(": ") {
+                return rest;
+            }
+        }
+    }
+    s
+}
+
+/// Replace `0x…`-style hex addresses with a placeholder so they don't make two
+/// otherwise-identical errors fingerprint differently.
+fn drop_hex_addrs(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if c == '0' && s[i..].starts_with("0x") {
+            out.push_str("0x");
+            // skip the "x" and the following hex digits
+            chars.next();
+            while let Some(&(_, h)) = chars.peek() {
+                if h.is_ascii_hexdigit() {
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PYTEST: &str = "\
+============================= test session starts =====
+collected 40 items
+
+tests/test_api.py EEEEEEEE.....F
+tests/test_auth.py EEEEEEEE
+
+==================================== ERRORS ====================================
+____ ERROR at setup of TestHealth.test_health_returns_ok ____
+    self._dbapi_connection = engine.raw_connection()
+E   sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name \"db\" to address: Temporary failure in name resolution
+(many more identical errors)
+============= 7 failed, 1 passed, 33 errors in 12.16s =============";
+
+    #[test]
+    fn excerpt_keeps_the_root_error_not_just_head_and_tail() {
+        let out = salient_excerpt(PYTEST, "", 4000);
+        // The middle error line — which blind head+tail would elide — survives.
+        assert!(out.contains("could not translate host name"), "got:\n{out}");
+        // And the summary tail survives too.
+        assert!(out.contains("33 errors"));
+    }
+
+    #[test]
+    fn excerpt_is_bounded_and_char_safe() {
+        let big = format!(
+            "head\n{}\nError: boom\n{}\ntail summary",
+            "x".repeat(9000),
+            "y".repeat(9000)
+        );
+        let out = salient_excerpt(&big, "", 1000);
+        assert!(out.len() <= 1000, "len={}", out.len());
+        assert!(out.contains("Error: boom") || out.contains("…"));
+        // Multibyte safety.
+        let uni = format!(
+            "{}\nErrore: però — × fallito\n{}",
+            "à".repeat(800),
+            "ò".repeat(800)
+        );
+        let _ = salient_excerpt(&uni, "", 200); // must not panic
+    }
+
+    #[test]
+    fn signature_is_stable_for_the_same_root_error() {
+        let s1 = error_signature(PYTEST, "");
+        let s2 = error_signature(&PYTEST.replace("12.16s", "9.02s"), ""); // timing differs
+        assert!(s1.is_some());
+        assert_eq!(s1, s2, "signature should ignore volatile timing");
+        assert!(s1.unwrap().contains("could not translate host name"));
+    }
+
+    #[test]
+    fn signature_differs_for_different_errors() {
+        let a = error_signature("E   ValueError: bad input", "").unwrap();
+        let b = error_signature("E   KeyError: 'missing'", "").unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn signature_none_when_no_error() {
+        assert_eq!(error_signature("all good\n2 passed", ""), None);
+    }
+
+    #[test]
+    fn signature_ignores_line_numbers_and_hex() {
+        let a = error_signature("foo.rs:10:5: error: mismatched types at 0x7f1a", "").unwrap();
+        let b = error_signature("foo.rs:88:9: error: mismatched types at 0x9c22", "").unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/cli/src/agent_host/mod.rs
+++ b/cli/src/agent_host/mod.rs
@@ -26,6 +26,7 @@
 
 pub mod allowlist;
 pub mod client;
+pub mod error_digest;
 pub mod protocol;
 pub mod runner;
 pub mod sandbox;

--- a/cli/src/agent_host/mod.rs
+++ b/cli/src/agent_host/mod.rs
@@ -30,3 +30,4 @@ pub mod protocol;
 pub mod runner;
 pub mod sandbox;
 pub mod signing;
+pub mod thrash_guard;

--- a/cli/src/agent_host/runner.rs
+++ b/cli/src/agent_host/runner.rs
@@ -643,6 +643,63 @@ fn spawn_failure_detail(base: &str, argv0: &str, not_found: bool, in_jail: bool)
     }
 }
 
+/// Build the `output` Value for a shell result and, for failures, an error
+/// signature for no-progress detection. Large *failing* output is replaced by
+/// an error-salient digest (feature "A") so the diagnosis survives the
+/// downstream context cap instead of being elided from the middle.
+fn shell_output_value(
+    stdout: &str,
+    stderr: &str,
+    returncode: Option<i32>,
+    is_error: bool,
+) -> (Value, Option<String>) {
+    let signature = if is_error {
+        super::error_digest::error_signature(stdout, stderr)
+    } else {
+        None
+    };
+    let combined_len = stdout.len() + stderr.len();
+    let budget = digest_budget();
+    if is_error && digest_enabled() && combined_len > budget {
+        let excerpt = super::error_digest::salient_excerpt(stdout, stderr, budget);
+        let value = json!({
+            "returncode": returncode,
+            "error_digest": excerpt,
+            "note": format!(
+                "output trimmed to salient error lines ({} of {} bytes); \
+                 set AGO_ERROR_DIGEST=false for the raw output",
+                excerpt.len(),
+                combined_len
+            ),
+        });
+        (value, signature)
+    } else {
+        (
+            json!({"stdout": stdout, "stderr": stderr, "returncode": returncode}),
+            signature,
+        )
+    }
+}
+
+fn digest_enabled() -> bool {
+    !matches!(
+        std::env::var("AGO_ERROR_DIGEST")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+fn digest_budget() -> usize {
+    std::env::var("AGO_ERROR_DIGEST_BYTES")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(4000)
+}
+
 fn finalise_shell(
     argv: Vec<String>,
     status: Option<std::process::ExitStatus>,
@@ -665,21 +722,20 @@ fn finalise_shell(
             );
     }
     if timed_out {
-        return ToolOutcome::err("shell_timeout")
+        let (output, signature) = shell_output_value(&stdout, &stderr, returncode, true);
+        let mut out = ToolOutcome::err("shell_timeout")
             .with_meta("argv0", json!(argv[0]))
-            .with_meta(
-                "output",
-                json!({"stdout": stdout, "stderr": stderr, "returncode": returncode}),
-            );
+            .with_meta("output", output);
+        if let Some(sig) = signature {
+            out.metadata.insert("error_signature".into(), json!(sig));
+        }
+        return out;
     }
     let success = returncode == Some(0);
+    let (output, signature) = shell_output_value(&stdout, &stderr, returncode, !success);
     let mut out = ToolOutcome {
         success,
-        output: json!({
-            "stdout": stdout,
-            "stderr": stderr,
-            "returncode": returncode,
-        }),
+        output,
         error_code: if success {
             None
         } else {
@@ -690,6 +746,9 @@ fn finalise_shell(
     out.metadata.insert("argv0".into(), json!(argv[0]));
     out.metadata
         .insert("elapsed_ms".into(), json!(elapsed.as_millis() as u64));
+    if let Some(sig) = signature {
+        out.metadata.insert("error_signature".into(), json!(sig));
+    }
     out
 }
 

--- a/cli/src/agent_host/thrash_guard.rs
+++ b/cli/src/agent_host/thrash_guard.rs
@@ -54,6 +54,9 @@ pub struct GuardConfig {
     /// Failures within the window (any command) that halt the turn — catches
     /// scattered-failure thrash the exact-repeat loop guard misses (0 = off).
     pub fail_density: u32,
+    /// Repeats of the same error *signature* (across any command) that trigger a
+    /// "no-progress" nudge injected into the tool result (0 = off). Feature "B".
+    pub no_progress: u32,
     /// Step index that halts the turn (0 = off).
     pub max_steps: u64,
     /// Cumulative turn cost (USD) that halts the turn (0 = off).
@@ -69,6 +72,7 @@ impl Default for GuardConfig {
             fail_warn: 8,
             fail_halt: 0,
             fail_density: 0,
+            no_progress: 3,
             max_steps: 0,
             max_usd: 0.0,
         }
@@ -103,6 +107,9 @@ impl GuardConfig {
             fail_density: env_u32_opt("AGO_FAIL_DENSITY")
                 .or(g.and_then(|g| g.fail_density))
                 .unwrap_or(d.fail_density),
+            no_progress: env_u32_opt("AGO_NO_PROGRESS")
+                .or(g.and_then(|g| g.no_progress))
+                .unwrap_or(d.no_progress),
             max_steps: env_u64_opt("AGO_TURN_MAX_STEPS")
                 .or(g.and_then(|g| g.max_steps))
                 .unwrap_or(d.max_steps),
@@ -135,6 +142,8 @@ pub struct TurnGuard {
     cfg: GuardConfig,
     /// Recent calls as `(hash, was_error)`, capped at `cfg.loop_window`.
     recent: VecDeque<(u64, bool)>,
+    /// Recent error signatures (any command), for no-progress detection.
+    recent_sigs: VecDeque<String>,
     /// Global consecutive-failure streak across all tools.
     consec_fail: u32,
     /// Whether the `fail_warn` notice has already fired this streak.
@@ -148,6 +157,7 @@ impl TurnGuard {
         Self {
             cfg,
             recent: VecDeque::new(),
+            recent_sigs: VecDeque::new(),
             consec_fail: 0,
             warned: false,
             halted: None,
@@ -244,6 +254,35 @@ impl TurnGuard {
         None
     }
 
+    /// Record an error *signature* (feature B). When the same signature recurs
+    /// `no_progress` times across recent attempts — regardless of which command
+    /// produced it — return a nudge to inject into the tool result: the agent is
+    /// changing commands but not the outcome, i.e. not converging.
+    pub fn note_signature(&mut self, signature: &str) -> Option<String> {
+        if self.cfg.no_progress == 0 || signature.is_empty() {
+            return None;
+        }
+        const WINDOW: usize = 16;
+        self.recent_sigs.push_back(signature.to_string());
+        while self.recent_sigs.len() > WINDOW {
+            self.recent_sigs.pop_front();
+        }
+        let count = self
+            .recent_sigs
+            .iter()
+            .filter(|s| s.as_str() == signature)
+            .count() as u32;
+        if count >= self.cfg.no_progress {
+            Some(format!(
+                "no-progress: the same error has occurred {count}× across your recent attempts — \
+                 \"{signature}\". The root cause has not changed; stop varying the command and \
+                 fix THIS (different file / config / approach), or report the blocker."
+            ))
+        } else {
+            None
+        }
+    }
+
     /// Call on each `Step` frame with the cumulative index and turn cost.
     /// Returns a message the first time a hard cap trips.
     pub fn on_step(&mut self, index: u64, cost_usd: f64) -> Option<String> {
@@ -283,6 +322,7 @@ impl TurnGuard {
     /// Reset all per-turn state. Call on `TurnEnd`.
     pub fn reset(&mut self) {
         self.recent.clear();
+        self.recent_sigs.clear();
         self.consec_fail = 0;
         self.warned = false;
         self.halted = None;
@@ -332,6 +372,7 @@ mod tests {
             fail_warn: 0,
             fail_halt: 0,
             fail_density: 0,
+            no_progress: 0,
             max_steps: 0,
             max_usd: 0.0,
         }
@@ -423,6 +464,27 @@ mod tests {
             g.before("other", &json!({"z": 9})),
             Decision::Block(_)
         ));
+    }
+
+    #[test]
+    fn no_progress_nudges_on_repeated_signature_across_commands() {
+        let mut c = cfg();
+        c.no_progress = 3;
+        let mut g = TurnGuard::new(c);
+        let sig = "operationalerror: could not translate host name \"db\"";
+        assert!(g.note_signature(sig).is_none()); // 1
+        assert!(g.note_signature(sig).is_none()); // 2
+        let n = g.note_signature(sig); // 3 → nudge, even though "commands" differ
+        assert!(
+            n.is_some_and(|m| m.starts_with("no-progress") && m.contains("could not translate"))
+        );
+        // A different error signature resets the count for that fingerprint.
+        assert!(g.note_signature("keyerror: 'x'").is_none());
+        // Empty signature / disabled → never nudges.
+        assert!(g.note_signature("").is_none());
+        let mut off = cfg();
+        off.no_progress = 0;
+        assert!(TurnGuard::new(off).note_signature(sig).is_none());
     }
 
     #[test]

--- a/cli/src/agent_host/thrash_guard.rs
+++ b/cli/src/agent_host/thrash_guard.rs
@@ -51,6 +51,9 @@ pub struct GuardConfig {
     pub fail_warn: u32,
     /// Consecutive failures that halt the turn (0 = off).
     pub fail_halt: u32,
+    /// Failures within the window (any command) that halt the turn — catches
+    /// scattered-failure thrash the exact-repeat loop guard misses (0 = off).
+    pub fail_density: u32,
     /// Step index that halts the turn (0 = off).
     pub max_steps: u64,
     /// Cumulative turn cost (USD) that halts the turn (0 = off).
@@ -65,6 +68,7 @@ impl Default for GuardConfig {
             loop_window: 10,
             fail_warn: 8,
             fail_halt: 0,
+            fail_density: 0,
             max_steps: 0,
             max_usd: 0.0,
         }
@@ -72,18 +76,46 @@ impl Default for GuardConfig {
 }
 
 impl GuardConfig {
-    /// Read overrides from the environment, falling back to [`Default`].
-    pub fn from_env() -> Self {
+    /// Resolve the effective config. Precedence per field, lowest to highest:
+    /// built-in [`Default`] < `.ago.yaml` `guard:` block < environment variable.
+    /// Env wins, matching the CLI's `flag > .ago.yaml > config` convention.
+    pub fn resolve(project: Option<&crate::project::GuardSettings>) -> Self {
         let d = Self::default();
+        let g = project;
         Self {
-            loop_guard: env_bool("AGO_LOOP_GUARD", d.loop_guard),
-            loop_threshold: env_u32("AGO_LOOP_THRESHOLD", d.loop_threshold).max(1),
-            loop_window: env_u32("AGO_LOOP_WINDOW", d.loop_window as u32).max(1) as usize,
-            fail_warn: env_u32("AGO_FAIL_WARN", d.fail_warn),
-            fail_halt: env_u32("AGO_FAIL_HALT", d.fail_halt),
-            max_steps: env_u64("AGO_TURN_MAX_STEPS", d.max_steps),
-            max_usd: env_f64("AGO_TURN_MAX_USD", d.max_usd),
+            loop_guard: env_bool_opt("AGO_LOOP_GUARD")
+                .or(g.and_then(|g| g.loop_guard))
+                .unwrap_or(d.loop_guard),
+            loop_threshold: env_u32_opt("AGO_LOOP_THRESHOLD")
+                .or(g.and_then(|g| g.loop_threshold))
+                .unwrap_or(d.loop_threshold)
+                .max(1),
+            loop_window: env_u32_opt("AGO_LOOP_WINDOW")
+                .or(g.and_then(|g| g.loop_window))
+                .unwrap_or(d.loop_window as u32)
+                .max(1) as usize,
+            fail_warn: env_u32_opt("AGO_FAIL_WARN")
+                .or(g.and_then(|g| g.fail_warn))
+                .unwrap_or(d.fail_warn),
+            fail_halt: env_u32_opt("AGO_FAIL_HALT")
+                .or(g.and_then(|g| g.fail_halt))
+                .unwrap_or(d.fail_halt),
+            fail_density: env_u32_opt("AGO_FAIL_DENSITY")
+                .or(g.and_then(|g| g.fail_density))
+                .unwrap_or(d.fail_density),
+            max_steps: env_u64_opt("AGO_TURN_MAX_STEPS")
+                .or(g.and_then(|g| g.max_steps))
+                .unwrap_or(d.max_steps),
+            max_usd: env_f64_opt("AGO_TURN_MAX_USD")
+                .or(g.and_then(|g| g.max_usd))
+                .filter(|v| v.is_finite() && *v >= 0.0)
+                .unwrap_or(d.max_usd),
         }
+    }
+
+    /// Env-only resolution (no `.ago.yaml` block).
+    pub fn from_env() -> Self {
+        Self::resolve(None)
     }
 }
 
@@ -172,6 +204,19 @@ impl TurnGuard {
             self.recent.pop_front();
         }
 
+        // Failure-density halt (any command): catches scattered-failure thrash —
+        // many *different* failing commands — that the exact-repeat loop guard
+        // misses. Evaluated over the same recent window on every result.
+        if self.cfg.fail_density > 0 && self.halted.is_none() {
+            let fails = self.recent.iter().filter(|(_, e)| *e).count() as u32;
+            if fails >= self.cfg.fail_density {
+                let win = self.recent.len();
+                return Some(self.halt(format!(
+                    "high failure density — {fails} of the last {win} tool calls failed"
+                )));
+            }
+        }
+
         if is_error {
             self.consec_fail += 1;
         } else {
@@ -244,36 +289,34 @@ impl TurnGuard {
     }
 }
 
-fn env_bool(key: &str, default: bool) -> bool {
-    match std::env::var(key) {
-        Ok(v) => !matches!(
+/// `Some` only when the env var is set and parses; otherwise `None` so the
+/// caller falls through to the next precedence layer. A set-but-garbage value
+/// is treated as unset.
+fn env_bool_opt(key: &str) -> Option<bool> {
+    std::env::var(key).ok().map(|v| {
+        !matches!(
             v.trim().to_ascii_lowercase().as_str(),
             "0" | "false" | "no" | "off"
-        ),
-        Err(_) => default,
-    }
+        )
+    })
 }
 
-fn env_u32(key: &str, default: u32) -> u32 {
+fn env_u32_opt(key: &str) -> Option<u32> {
     std::env::var(key)
         .ok()
         .and_then(|v| v.trim().parse::<u32>().ok())
-        .unwrap_or(default)
 }
 
-fn env_u64(key: &str, default: u64) -> u64 {
+fn env_u64_opt(key: &str) -> Option<u64> {
     std::env::var(key)
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(default)
 }
 
-fn env_f64(key: &str, default: f64) -> f64 {
+fn env_f64_opt(key: &str) -> Option<f64> {
     std::env::var(key)
         .ok()
         .and_then(|v| v.trim().parse::<f64>().ok())
-        .filter(|v| v.is_finite() && *v >= 0.0)
-        .unwrap_or(default)
 }
 
 #[cfg(test)]
@@ -288,6 +331,7 @@ mod tests {
             loop_window: 10,
             fail_warn: 0,
             fail_halt: 0,
+            fail_density: 0,
             max_steps: 0,
             max_usd: 0.0,
         }
@@ -401,6 +445,51 @@ mod tests {
         assert!(g.on_step(5, 0.49).is_none());
         assert!(g.on_step(6, 0.51).is_some_and(|m| m.contains("cost cap")));
         assert!(g.is_halted());
+    }
+
+    #[test]
+    fn failure_density_halts_on_scattered_failures() {
+        // Many *different* failing commands (loop guard alone never blocks them)
+        // must still trip the density halt: 7 of the last 10 failed.
+        let mut c = cfg();
+        c.fail_density = 7;
+        let mut g = TurnGuard::new(c);
+        let mut tripped = false;
+        for i in 0..10 {
+            let args = json!({ "argv": [format!("cmd{i}")] }); // each call is unique
+            assert_eq!(g.before("shell_exec", &args), Decision::Allow);
+            // 7 failures interleaved with 3 successes.
+            let is_err = i < 7;
+            if let Some(m) = g.after("shell_exec", &args, is_err) {
+                assert!(m.contains("failure density"), "got: {m}");
+                tripped = true;
+                break;
+            }
+        }
+        assert!(tripped, "density halt should fire on 7/10 failures");
+        assert!(g.is_halted());
+    }
+
+    #[test]
+    fn resolve_precedence_default_yaml_env() {
+        use crate::project::GuardSettings;
+        // Default when neither yaml nor env set.
+        assert_eq!(GuardConfig::resolve(None).loop_threshold, 3);
+        // YAML overrides default.
+        let ys = GuardSettings {
+            loop_threshold: Some(5),
+            max_usd: Some(0.25),
+            ..Default::default()
+        };
+        let r = GuardConfig::resolve(Some(&ys));
+        assert_eq!(r.loop_threshold, 5);
+        assert_eq!(r.max_usd, 0.25);
+        // Env overrides YAML (serialised: env vars are process-global).
+        std::env::set_var("AGO_LOOP_THRESHOLD", "9");
+        let r = GuardConfig::resolve(Some(&ys));
+        std::env::remove_var("AGO_LOOP_THRESHOLD");
+        assert_eq!(r.loop_threshold, 9);
+        assert_eq!(r.max_usd, 0.25); // untouched by env
     }
 
     #[test]

--- a/cli/src/agent_host/thrash_guard.rs
+++ b/cli/src/agent_host/thrash_guard.rs
@@ -492,6 +492,28 @@ mod tests {
         assert_eq!(r.max_usd, 0.25); // untouched by env
     }
 
+    // Regression: handle_tool_call's block path locks the guard for `before`
+    // and again for `after`. The tokio Mutex is NOT re-entrant, so holding the
+    // first lock across the body (e.g. via an `if let` temporary) deadlocks.
+    // This mirrors the corrected sequence and asserts it completes promptly.
+    #[tokio::test]
+    async fn halted_block_path_does_not_deadlock() {
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::sync::Mutex;
+        let mut c = cfg();
+        c.max_steps = 1;
+        let g = Arc::new(Mutex::new(TurnGuard::new(c)));
+        g.lock().await.on_step(1, 0.0); // halt the turn
+        let r = tokio::time::timeout(Duration::from_secs(2), async {
+            let decision = g.lock().await.before("t", &json!({})); // lock released here
+            assert!(matches!(decision, Decision::Block(_)));
+            g.lock().await.after("t", &json!({}), true); // would hang if still held
+        })
+        .await;
+        assert!(r.is_ok(), "block path deadlocked");
+    }
+
     #[test]
     fn reset_clears_halt_and_streak() {
         let mut c = cfg();

--- a/cli/src/agent_host/thrash_guard.rs
+++ b/cli/src/agent_host/thrash_guard.rs
@@ -1,0 +1,417 @@
+//! Client-side thrash guard for `--client-tools` turns.
+//!
+//! In client-tools mode the agent loop runs on the SERVER; the CLI only
+//! shuttles tool calls/results over the WebSocket. The server has its own
+//! loop/failure guards, but they can leak: in multi-agent fan-out `max_steps`
+//! is per-agent (so a team-lead run easily exceeds it), and the server loop
+//! detector hashes the *exact* tool call, so a shell command that varies by a
+//! byte slips past. The result is the failure mode we actually observed — a
+//! turn that ran ~86 steps re-running near-identical failing commands while the
+//! per-step latency climbed with the context.
+//!
+//! This guard sits at the one choke point the CLI fully controls — the
+//! tool-execution boundary — and limits the *local* damage without needing any
+//! new protocol frame:
+//!
+//! 1. **Loop guard (`AGO_LOOP_GUARD`, on by default).** If the same tool call
+//!    (name + canonical args) has *failed* `threshold` times within the recent
+//!    `window`, the next identical call is NOT executed: it is short-circuited
+//!    with a synthetic `loop_blocked` error that nudges the server to change
+//!    approach. We count *failures only*, so legitimate polling (e.g. waiting
+//!    for `docker compose ps` to report healthy) — which returns success — never
+//!    trips it. This is the OpenHands "repeating action + error" lesson:
+//!    blocking on bare repetition kills agents that are correctly waiting.
+//! 2. **Consecutive-failure breaker (`AGO_FAIL_WARN` / `AGO_FAIL_HALT`).** A
+//!    global streak counter over every tool result. At `warn` it prints a
+//!    prominent notice; at `halt` (opt-in) it stops running further tools this
+//!    turn.
+//! 3. **Hard step/cost caps (`AGO_TURN_MAX_STEPS` / `AGO_TURN_MAX_USD`,
+//!    opt-in).** Fed from each `Step` frame's cumulative index/cost. Once a cap
+//!    trips, the turn is *halted*: every further tool call is refused so no more
+//!    commands run on your machine. This is the "the system, not the agent,
+//!    guarantees termination" backstop.
+//!
+//! All thresholds are environment-tunable; the loop guard is the only one on by
+//! default because it is precise (failures-only) and low-false-positive.
+
+use std::collections::VecDeque;
+
+use sha2::{Digest, Sha256};
+
+/// Resolved guard configuration. Built once per session from the environment.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GuardConfig {
+    /// Block identical *failing* calls. Default on.
+    pub loop_guard: bool,
+    /// How many failing repeats within the window trigger a block.
+    pub loop_threshold: u32,
+    /// Size of the recent-call window the loop guard looks back over.
+    pub loop_window: usize,
+    /// Consecutive failures that print a warning (0 = off).
+    pub fail_warn: u32,
+    /// Consecutive failures that halt the turn (0 = off).
+    pub fail_halt: u32,
+    /// Step index that halts the turn (0 = off).
+    pub max_steps: u64,
+    /// Cumulative turn cost (USD) that halts the turn (0 = off).
+    pub max_usd: f64,
+}
+
+impl Default for GuardConfig {
+    fn default() -> Self {
+        Self {
+            loop_guard: true,
+            loop_threshold: 3,
+            loop_window: 10,
+            fail_warn: 8,
+            fail_halt: 0,
+            max_steps: 0,
+            max_usd: 0.0,
+        }
+    }
+}
+
+impl GuardConfig {
+    /// Read overrides from the environment, falling back to [`Default`].
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            loop_guard: env_bool("AGO_LOOP_GUARD", d.loop_guard),
+            loop_threshold: env_u32("AGO_LOOP_THRESHOLD", d.loop_threshold).max(1),
+            loop_window: env_u32("AGO_LOOP_WINDOW", d.loop_window as u32).max(1) as usize,
+            fail_warn: env_u32("AGO_FAIL_WARN", d.fail_warn),
+            fail_halt: env_u32("AGO_FAIL_HALT", d.fail_halt),
+            max_steps: env_u64("AGO_TURN_MAX_STEPS", d.max_steps),
+            max_usd: env_f64("AGO_TURN_MAX_USD", d.max_usd),
+        }
+    }
+}
+
+/// Decision returned by [`TurnGuard::before`] for a pending tool call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    /// Run the tool normally.
+    Allow,
+    /// Do not run the tool; return this synthetic error reason instead.
+    Block(String),
+}
+
+/// Per-turn thrash detector. Cheap; reset between turns via [`reset`].
+///
+/// [`reset`]: TurnGuard::reset
+pub struct TurnGuard {
+    cfg: GuardConfig,
+    /// Recent calls as `(hash, was_error)`, capped at `cfg.loop_window`.
+    recent: VecDeque<(u64, bool)>,
+    /// Global consecutive-failure streak across all tools.
+    consec_fail: u32,
+    /// Whether the `fail_warn` notice has already fired this streak.
+    warned: bool,
+    /// `Some(reason)` once the turn is halted; refuses all further tools.
+    halted: Option<String>,
+}
+
+impl TurnGuard {
+    pub fn new(cfg: GuardConfig) -> Self {
+        Self {
+            cfg,
+            recent: VecDeque::new(),
+            consec_fail: 0,
+            warned: false,
+            halted: None,
+        }
+    }
+
+    /// Stable 64-bit hash of `(name, canonical-args)`. `serde_json` serialises
+    /// object keys in sorted order by default (no `preserve_order` feature), so
+    /// `to_string` is already canonical for our argument shapes.
+    fn hash(name: &str, args: &serde_json::Value) -> u64 {
+        let mut h = Sha256::new();
+        h.update(name.as_bytes());
+        h.update([0u8]);
+        h.update(serde_json::to_string(args).unwrap_or_default().as_bytes());
+        let digest = h.finalize();
+        u64::from_be_bytes(digest[..8].try_into().expect("sha256 >= 8 bytes"))
+    }
+
+    /// Call BEFORE executing a tool. Returns whether to run it.
+    pub fn before(&mut self, name: &str, args: &serde_json::Value) -> Decision {
+        if let Some(reason) = &self.halted {
+            return Decision::Block(reason.clone());
+        }
+        if !self.cfg.loop_guard {
+            return Decision::Allow;
+        }
+        let h = Self::hash(name, args);
+        let failures = self
+            .recent
+            .iter()
+            .filter(|(hh, was_err)| *hh == h && *was_err)
+            .count() as u32;
+        if failures >= self.cfg.loop_threshold {
+            return Decision::Block(format!(
+                "loop_blocked: this exact `{name}` call has already failed {failures}× recently \
+                 — change approach instead of retrying the same command \
+                 (disable with AGO_LOOP_GUARD=false)"
+            ));
+        }
+        Decision::Allow
+    }
+
+    /// Call AFTER a tool result (executed or blocked). Records the outcome and
+    /// returns a one-line warning to print, if any.
+    pub fn after(
+        &mut self,
+        name: &str,
+        args: &serde_json::Value,
+        is_error: bool,
+    ) -> Option<String> {
+        let h = Self::hash(name, args);
+        self.recent.push_back((h, is_error));
+        while self.recent.len() > self.cfg.loop_window {
+            self.recent.pop_front();
+        }
+
+        if is_error {
+            self.consec_fail += 1;
+        } else {
+            self.consec_fail = 0;
+            self.warned = false;
+            return None;
+        }
+
+        // Halt takes precedence over the (lighter) warning.
+        if self.cfg.fail_halt > 0 && self.consec_fail >= self.cfg.fail_halt && self.halted.is_none()
+        {
+            let n = self.consec_fail;
+            return Some(self.halt(format!(
+                "{n} tool calls failed in a row — halting the turn to stop the thrash"
+            )));
+        }
+        if self.cfg.fail_warn > 0 && self.consec_fail == self.cfg.fail_warn && !self.warned {
+            self.warned = true;
+            let n = self.consec_fail;
+            return Some(format!(
+                "⚠ {n} tool calls have failed in a row — the agent may be stuck; \
+                 press Ctrl-C or type :quit to stop"
+            ));
+        }
+        None
+    }
+
+    /// Call on each `Step` frame with the cumulative index and turn cost.
+    /// Returns a message the first time a hard cap trips.
+    pub fn on_step(&mut self, index: u64, cost_usd: f64) -> Option<String> {
+        if self.halted.is_some() {
+            return None;
+        }
+        if self.cfg.max_steps > 0 && index >= self.cfg.max_steps {
+            return Some(self.halt(format!(
+                "step cap reached ({index} ≥ AGO_TURN_MAX_STEPS={})",
+                self.cfg.max_steps
+            )));
+        }
+        if self.cfg.max_usd > 0.0 && cost_usd >= self.cfg.max_usd {
+            return Some(self.halt(format!(
+                "cost cap reached (${cost_usd:.4} ≥ AGO_TURN_MAX_USD=${:.4})",
+                self.cfg.max_usd
+            )));
+        }
+        None
+    }
+
+    /// Mark the turn halted and return the user-facing message.
+    fn halt(&mut self, why: String) -> String {
+        let msg = format!(
+            "⊘ turn halted by client: {why}. No further tools will run this turn — \
+             press Ctrl-C or type :quit (resume later with --resume)."
+        );
+        self.halted = Some(format!("turn_halted_by_client: {why}"));
+        msg
+    }
+
+    /// Whether the turn is currently halted.
+    pub fn is_halted(&self) -> bool {
+        self.halted.is_some()
+    }
+
+    /// Reset all per-turn state. Call on `TurnEnd`.
+    pub fn reset(&mut self) {
+        self.recent.clear();
+        self.consec_fail = 0;
+        self.warned = false;
+        self.halted = None;
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        Err(_) => default,
+    }
+}
+
+fn env_u32(key: &str, default: u32) -> u32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn env_f64(key: &str, default: f64) -> f64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|v| v.is_finite() && *v >= 0.0)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn cfg() -> GuardConfig {
+        GuardConfig {
+            loop_guard: true,
+            loop_threshold: 3,
+            loop_window: 10,
+            fail_warn: 0,
+            fail_halt: 0,
+            max_steps: 0,
+            max_usd: 0.0,
+        }
+    }
+
+    #[test]
+    fn allows_until_threshold_then_blocks_repeated_failures() {
+        let mut g = TurnGuard::new(cfg());
+        let args = json!({"argv": ["docker", "compose", "up"]});
+        // 3 failures recorded → the 4th identical call is blocked.
+        for _ in 0..3 {
+            assert_eq!(g.before("shell_exec", &args), Decision::Allow);
+            g.after("shell_exec", &args, true);
+        }
+        match g.before("shell_exec", &args) {
+            Decision::Block(r) => assert!(r.starts_with("loop_blocked"), "got: {r}"),
+            Decision::Allow => panic!("expected block after 3 failures"),
+        }
+    }
+
+    #[test]
+    fn successful_polling_never_blocks() {
+        let mut g = TurnGuard::new(cfg());
+        let args = json!({"argv": ["docker", "compose", "ps"]});
+        // 20 identical *successful* calls (legit polling) must never trip.
+        for _ in 0..20 {
+            assert_eq!(g.before("shell_exec", &args), Decision::Allow);
+            g.after("shell_exec", &args, false);
+        }
+    }
+
+    #[test]
+    fn different_args_tracked_separately() {
+        let mut g = TurnGuard::new(cfg());
+        let a = json!({"argv": ["a"]});
+        let b = json!({"argv": ["b"]});
+        for _ in 0..3 {
+            g.before("shell_exec", &a);
+            g.after("shell_exec", &a, true);
+        }
+        // `a` is now blocked, but a fresh `b` is still allowed.
+        assert!(matches!(g.before("shell_exec", &a), Decision::Block(_)));
+        assert_eq!(g.before("shell_exec", &b), Decision::Allow);
+    }
+
+    #[test]
+    fn loop_guard_off_never_blocks() {
+        let mut c = cfg();
+        c.loop_guard = false;
+        let mut g = TurnGuard::new(c);
+        let args = json!({"argv": ["x"]});
+        for _ in 0..10 {
+            assert_eq!(g.before("shell_exec", &args), Decision::Allow);
+            g.after("shell_exec", &args, true);
+        }
+    }
+
+    #[test]
+    fn consecutive_failures_warn_once_then_reset_on_success() {
+        let mut c = cfg();
+        c.loop_guard = false; // isolate the breaker from the loop guard
+        c.fail_warn = 3;
+        let mut g = TurnGuard::new(c);
+        let a = json!({"argv": ["1"]});
+        assert!(g.after("t", &a, true).is_none());
+        assert!(g.after("t", &a, true).is_none());
+        let w = g.after("t", &a, true);
+        assert!(w.is_some_and(|m| m.contains("failed in a row")));
+        // Already warned → no repeat at 4.
+        assert!(g.after("t", &a, true).is_none());
+        // Success resets; the streak can warn again later.
+        assert!(g.after("t", &a, false).is_none());
+        assert_eq!(g.consec_fail, 0);
+    }
+
+    #[test]
+    fn fail_halt_stops_all_further_tools() {
+        let mut c = cfg();
+        c.loop_guard = false;
+        c.fail_halt = 2;
+        let mut g = TurnGuard::new(c);
+        let a = json!({"a": 1});
+        g.after("t", &a, true);
+        let msg = g.after("t", &a, true);
+        assert!(msg.is_some_and(|m| m.contains("halted")));
+        assert!(g.is_halted());
+        // Once halted, even a brand-new tool call is refused.
+        assert!(matches!(
+            g.before("other", &json!({"z": 9})),
+            Decision::Block(_)
+        ));
+    }
+
+    #[test]
+    fn step_cap_halts_turn() {
+        let mut c = cfg();
+        c.max_steps = 40;
+        let mut g = TurnGuard::new(c);
+        assert!(g.on_step(39, 0.0).is_none());
+        assert!(g.on_step(40, 0.0).is_some_and(|m| m.contains("step cap")));
+        assert!(g.is_halted());
+        // Subsequent steps do not re-fire.
+        assert!(g.on_step(41, 0.0).is_none());
+    }
+
+    #[test]
+    fn cost_cap_halts_turn() {
+        let mut c = cfg();
+        c.max_usd = 0.50;
+        let mut g = TurnGuard::new(c);
+        assert!(g.on_step(5, 0.49).is_none());
+        assert!(g.on_step(6, 0.51).is_some_and(|m| m.contains("cost cap")));
+        assert!(g.is_halted());
+    }
+
+    #[test]
+    fn reset_clears_halt_and_streak() {
+        let mut c = cfg();
+        c.max_steps = 10;
+        let mut g = TurnGuard::new(c);
+        g.on_step(10, 0.0);
+        assert!(g.is_halted());
+        g.reset();
+        assert!(!g.is_halted());
+        assert_eq!(g.before("t", &json!({})), Decision::Allow);
+    }
+}

--- a/cli/src/commands/chat.rs
+++ b/cli/src/commands/chat.rs
@@ -488,6 +488,9 @@ struct ChatSettings {
     shell_allow: Vec<String>,
     shell_deny: Vec<String>,
     shell_allow_all: bool,
+    /// Resolved client-side thrash-guard config (default < `.ago.yaml` `guard:`
+    /// < env). Only consumed by the `--client-tools` (`run_repl`) path.
+    guard: crate::agent_host::thrash_guard::GuardConfig,
 }
 
 impl ChatSettings {
@@ -519,6 +522,9 @@ impl ChatSettings {
             .and_then(|p| p.shell.as_ref())
             .map(|s| (s.allow.clone(), s.deny.clone(), s.allow_all))
             .unwrap_or_default();
+        let guard = crate::agent_host::thrash_guard::GuardConfig::resolve(
+            preset.and_then(|p| p.guard.as_ref()),
+        );
         Ok(Self {
             mode: args.mode,
             agent,
@@ -529,6 +535,7 @@ impl ChatSettings {
             shell_allow,
             shell_deny,
             shell_allow_all,
+            guard,
         })
     }
 }
@@ -1223,6 +1230,7 @@ async fn run_native_agent_host(
         &settings.shell_allow,
         &settings.shell_deny,
         settings.shell_allow_all,
+        settings.guard.clone(),
         instructions,
     )
     .await
@@ -1249,6 +1257,7 @@ mod tests {
             shell_allow: Vec::new(),
             shell_deny: Vec::new(),
             shell_allow_all: false,
+            guard: crate::agent_host::thrash_guard::GuardConfig::default(),
         }
     }
 

--- a/cli/src/commands/run.rs
+++ b/cli/src/commands/run.rs
@@ -875,6 +875,7 @@ mod tests {
                 jail: None,
                 jail_image: None,
                 jail_docker: None,
+                guard: None,
             },
             None,
         );
@@ -927,6 +928,7 @@ mod tests {
                 jail: None,
                 jail_image: None,
                 jail_docker: None,
+                guard: None,
             },
             None,
         );

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -89,6 +89,9 @@ pub struct GuardSettings {
     /// Failures within the window (any command) that halt the turn — catches
     /// scattered-failure thrash the exact-repeat guard misses (default 0 = off).
     pub fail_density: Option<u32>,
+    /// Repeats of the same error signature that trigger a no-progress nudge
+    /// injected into the tool result (default 3; 0 = off).
+    pub no_progress: Option<u32>,
     /// Step index that halts the turn (default 0 = off).
     pub max_steps: Option<u64>,
     /// Cumulative turn cost (USD) that halts the turn (default 0 = off).

--- a/cli/src/project.rs
+++ b/cli/src/project.rs
@@ -21,7 +21,9 @@ use std::path::{Path, PathBuf};
 pub const PROJECT_FILE_PRIMARY: &str = ".ago.yaml";
 pub const PROJECT_FILE_FALLBACK: &str = ".ago.yml";
 
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq)]
+// No `Eq`: the nested `guard` block carries an f64 (`max_usd`), which is not
+// `Eq`. `PartialEq` is all the tests need.
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectPreset {
     pub server: Option<String>,
@@ -59,6 +61,38 @@ pub struct ProjectPreset {
     /// DANGER: handing the Docker socket to the sandbox is root-equivalent on the
     /// host and punctures the jail's file isolation. Defaults to `false`.
     pub jail_docker: Option<bool>,
+    /// Client-side thrash-guard tuning for `--client-tools` runs (loop guard,
+    /// failure breaker, hard step/cost caps). Lets a project that tends to thrash
+    /// pin sensible caps without remembering env vars each session. Env vars
+    /// (`AGO_LOOP_GUARD`, `AGO_TURN_MAX_STEPS`, …) still override these. See
+    /// [`crate::agent_host::thrash_guard`].
+    pub guard: Option<GuardSettings>,
+}
+
+/// Per-project overrides for the client-side thrash guard. Every field is
+/// optional; a `None` keeps the built-in default. Resolution precedence for the
+/// final value is **env var > this block > built-in default** (see
+/// [`crate::agent_host::thrash_guard::GuardConfig::resolve`]).
+#[derive(Debug, Default, Clone, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct GuardSettings {
+    /// Block identical *failing* calls (default true).
+    pub loop_guard: Option<bool>,
+    /// Failing repeats within the window that trigger a block (default 3).
+    pub loop_threshold: Option<u32>,
+    /// Recent-call window the guard looks back over (default 10).
+    pub loop_window: Option<u32>,
+    /// Consecutive failures that print a warning (default 8; 0 = off).
+    pub fail_warn: Option<u32>,
+    /// Consecutive failures that halt the turn (default 0 = off).
+    pub fail_halt: Option<u32>,
+    /// Failures within the window (any command) that halt the turn — catches
+    /// scattered-failure thrash the exact-repeat guard misses (default 0 = off).
+    pub fail_density: Option<u32>,
+    /// Step index that halts the turn (default 0 = off).
+    pub max_steps: Option<u64>,
+    /// Cumulative turn cost (USD) that halts the turn (default 0 = off).
+    pub max_usd: Option<f64>,
 }
 
 /// Project-scoped shell policy layered on top of the global allowlist cache.

--- a/docs/ago-cli-improvements.md
+++ b/docs/ago-cli-improvements.md
@@ -482,6 +482,35 @@ sweep shows that still keeps `early` facts, trading only mid-run detail.
 
 ---
 
+### Diagnosing a session — richer `--log-file` + `analyze_ago_session.py` — ✅ DONE
+
+> **Observed.** Watching a live `--log-file`, a stuck turn read as "35 file_read,
+> 24 shell_exec, 0 file_write" — you could see it was *spinning* but not *which*
+> files or commands, because the trace logged only the tool **name**.
+
+Two changes make a session diagnosable from the log alone:
+
+- **`args=` in the `tool_call` line** (`cli/src/agent_host/client.rs`,
+  `summarize_args`): `shell_exec` logs the command, `file_read`/`file_write` log
+  the path. A failing or looping command is now named in the trace, not just
+  counted. Test: `summarize_args_shows_command_path_and_keys`.
+- **`scripts/analyze_ago_session.py`** turns one or more logs into a per-turn
+  table (agents, steps/budget, tokens, cost, writes, errors, status) plus **red
+  flags** that map straight to fixes: `0 file_write` (spinning), step overshoot,
+  `shell_timeout` (watch-mode hang), the same command failing ≥3×, and cost
+  blow-ups — and a **most-failed-commands** roll-up across the session.
+
+```bash
+python scripts/analyze_ago_session.py ~/ago-session_10.log
+python scripts/analyze_ago_session.py ~/ago-session*.log --json
+```
+
+Run against the 2026-06-14 testAgo trace it summarised **26 turns / $1.36** and
+flagged exactly the known faults (96-vs-40 overshoot, 3× `shell_timeout`,
+35× repeated `shell_exec` failure). Tests: `tests/test_analyze_ago_session.py`.
+
+---
+
 ### P1 — Tool outputs are not capped before re-entering context — ✅ DONE
 
 > **Status: implemented.** `core/agent.py` now folds each tool result into

--- a/docs/managing-local-projects.md
+++ b/docs/managing-local-projects.md
@@ -104,7 +104,7 @@ shell:
 ```
 
 Allowed keys: `server`, `agent`, `model`, `provider`, `max_steps`,
-`context`, `shell`, `jail`, `jail_image`, `jail_docker`. CLI flags override `.ago.yaml`;
+`context`, `shell`, `jail`, `jail_image`, `jail_docker`, `guard`. CLI flags override `.ago.yaml`;
 `.ago.yaml` overrides `~/.config/ago/config.toml`. Empty values fall through to
 the next layer.
 
@@ -450,22 +450,36 @@ damage:
 
 | Mechanism | Env (default) | Behaviour |
 |---|---|---|
-| **Loop guard** | `AGO_LOOP_GUARD` (**on**), `AGO_LOOP_THRESHOLD` (3), `AGO_LOOP_WINDOW` (10) | If the same call has **failed** ≥ threshold times in the recent window, the next identical call is **not executed** — it returns a synthetic `loop_blocked` error that nudges the agent to change approach. Counts *failures only*, so legitimate polling (e.g. waiting for `docker compose ps` to go healthy, which returns success) never trips it. |
-| **Failure breaker** | `AGO_FAIL_WARN` (8), `AGO_FAIL_HALT` (0 = off) | A global consecutive-failure streak. At `warn` it prints a notice; at `halt` (opt-in) it stops running further tools this turn. |
+| **Loop guard** | `AGO_LOOP_GUARD` (**on**), `AGO_LOOP_THRESHOLD` (3), `AGO_LOOP_WINDOW` (10) | If the **same** call has **failed** ≥ threshold times in the recent window, the next identical call is **not executed** — it returns a synthetic `loop_blocked` error that nudges the agent to change approach. Counts *failures only*, so legitimate polling (e.g. waiting for `docker compose ps` to go healthy, which returns success) never trips it. |
+| **Failure density** | `AGO_FAIL_DENSITY` (0 = off) | Catches *scattered*-failure thrash that the exact-repeat loop guard misses — many **different** failing commands. Halts the turn when ≥ N of the last `AGO_LOOP_WINDOW` tool calls failed, regardless of which command. |
+| **Failure breaker** | `AGO_FAIL_WARN` (8), `AGO_FAIL_HALT` (0 = off) | A global *consecutive*-failure streak. At `warn` it prints a notice; at `halt` (opt-in) it stops running further tools this turn. |
 | **Hard caps** | `AGO_TURN_MAX_STEPS` (0 = off), `AGO_TURN_MAX_USD` (0 = off) | Fed from each `Step` frame. Once a cap trips the turn is **halted**: every further tool call is refused so no more commands run on your machine. |
 
-When a cap or the breaker halts the turn you'll see, on stderr:
+When a cap, the breaker, or density halts the turn you'll see, on stderr:
 
 ```
-⊘ turn halted by client: step cap reached (40 ≥ AGO_TURN_MAX_STEPS=40). No further
-  tools will run this turn — press Ctrl-C or type :quit (resume later with --resume).
+⊘ turn halted by client: high failure density — 8 of the last 10 tool calls failed.
+  No further tools will run this turn — press Ctrl-C or type :quit (resume with --resume).
 ```
 
 Only the **loop guard** is on by default (it is precise — failures-only — and
-low-false-positive). The breaker-halt and hard caps are opt-in; set them per
-session, e.g. `AGO_TURN_MAX_USD=0.50 ago chat --client-tools`. Disable the loop
-guard entirely with `AGO_LOOP_GUARD=false` if an agent legitimately needs to
-retry an identical failing command.
+low-false-positive). Density, the breaker-halt, and the hard caps are opt-in;
+set them per session, e.g. `AGO_TURN_MAX_USD=0.50 ago chat --client-tools`.
+Disable the loop guard entirely with `AGO_LOOP_GUARD=false` if an agent
+legitimately needs to retry an identical failing command.
+
+**Pin the limits per project (`.ago.yaml`).** So you don't repeat env vars each
+session, set a `guard:` block — env vars still override it. Useful for a project
+whose agent tends to thrash on scattered failures:
+
+```yaml
+# .ago.yaml — precedence per field: built-in default < this block < env var
+guard:
+  fail_density: 8   # halt if 8 of the last 10 tool calls failed (any command)
+  max_steps: 60     # hard stop (multi-agent fan-out overruns the agent max_steps)
+  max_usd: 0.30     # hard cost ceiling per turn
+  # also available: loop_guard, loop_threshold, loop_window, fail_warn, fail_halt
+```
 
 ---
 

--- a/docs/managing-local-projects.md
+++ b/docs/managing-local-projects.md
@@ -454,6 +454,21 @@ damage:
 | **Failure density** | `AGO_FAIL_DENSITY` (0 = off) | Catches *scattered*-failure thrash that the exact-repeat loop guard misses — many **different** failing commands. Halts the turn when ≥ N of the last `AGO_LOOP_WINDOW` tool calls failed, regardless of which command. |
 | **Failure breaker** | `AGO_FAIL_WARN` (8), `AGO_FAIL_HALT` (0 = off) | A global *consecutive*-failure streak. At `warn` it prints a notice; at `halt` (opt-in) it stops running further tools this turn. |
 | **Hard caps** | `AGO_TURN_MAX_STEPS` (0 = off), `AGO_TURN_MAX_USD` (0 = off) | Fed from each `Step` frame. Once a cap trips the turn is **halted**: every further tool call is refused so no more commands run on your machine. |
+| **No-progress nudge** | `AGO_NO_PROGRESS` (3; 0 = off) | Convergence aid, not a brake. Fingerprints each failed command's *error* (not the command). When the same error signature recurs ≥ N times — even across **different** commands — a `no-progress` note is injected into the tool result telling the agent the root cause is unchanged, so it stops varying the command and fixes the actual error. |
+
+These last two are the *anti-thrash* (halt) layer; the loop/density/breaker stop
+runaway. The **error digest** below is the *convergence* layer — it helps the
+agent fix the problem rather than just stopping it.
+
+**Error digest (`AGO_ERROR_DIGEST`, on; `AGO_ERROR_DIGEST_BYTES`, 4000).** When a
+`shell_exec` fails with large output (a pytest run, a `cargo`/`tsc` build, a
+`docker compose` log), the downstream context cap keeps only a head+tail slice —
+which preserves the *summary* (`34 errors`) but elides the **middle**, where the
+actual diagnosis lives (the first traceback, the `OperationalError: …` line, the
+`error[E0599]`). The CLI holds the full output, so for failures it sends an
+**error-salient digest** instead (head + the error/traceback lines + tail),
+guaranteeing the root cause survives. This is what feeds the no-progress
+fingerprint above. Disable with `AGO_ERROR_DIGEST=false` to send raw output.
 
 When a cap, the breaker, or density halts the turn you'll see, on stderr:
 

--- a/docs/managing-local-projects.md
+++ b/docs/managing-local-projects.md
@@ -435,6 +435,38 @@ Resource bounds the server enforces:
   to 100). Sent in the handshake, so `ago chat --client-tools --max-steps 50`
   gives a long multi-step task more room before `Max steps reached`.
 
+### Thrash guard (client-side loop & cost limits)
+
+The agent loop runs **server-side**, and its own loop/failure guards can leak:
+in multi-agent fan-out `max_steps` is *per-agent* (so a team-lead run easily
+runs past it), and the server's loop detector hashes the *exact* tool call, so a
+shell command that varies by a byte slips past. The symptom is a turn that keeps
+re-running near-identical **failing** commands while per-step latency climbs with
+the context.
+
+The CLI adds an independent guard at the one choke point it controls — the
+tool-execution boundary. It needs no server cooperation and limits the *local*
+damage:
+
+| Mechanism | Env (default) | Behaviour |
+|---|---|---|
+| **Loop guard** | `AGO_LOOP_GUARD` (**on**), `AGO_LOOP_THRESHOLD` (3), `AGO_LOOP_WINDOW` (10) | If the same call has **failed** ≥ threshold times in the recent window, the next identical call is **not executed** — it returns a synthetic `loop_blocked` error that nudges the agent to change approach. Counts *failures only*, so legitimate polling (e.g. waiting for `docker compose ps` to go healthy, which returns success) never trips it. |
+| **Failure breaker** | `AGO_FAIL_WARN` (8), `AGO_FAIL_HALT` (0 = off) | A global consecutive-failure streak. At `warn` it prints a notice; at `halt` (opt-in) it stops running further tools this turn. |
+| **Hard caps** | `AGO_TURN_MAX_STEPS` (0 = off), `AGO_TURN_MAX_USD` (0 = off) | Fed from each `Step` frame. Once a cap trips the turn is **halted**: every further tool call is refused so no more commands run on your machine. |
+
+When a cap or the breaker halts the turn you'll see, on stderr:
+
+```
+⊘ turn halted by client: step cap reached (40 ≥ AGO_TURN_MAX_STEPS=40). No further
+  tools will run this turn — press Ctrl-C or type :quit (resume later with --resume).
+```
+
+Only the **loop guard** is on by default (it is precise — failures-only — and
+low-false-positive). The breaker-halt and hard caps are opt-in; set them per
+session, e.g. `AGO_TURN_MAX_USD=0.50 ago chat --client-tools`. Disable the loop
+guard entirely with `AGO_LOOP_GUARD=false` if an agent legitimately needs to
+retry an identical failing command.
+
 ---
 
 ## Troubleshooting

--- a/scripts/analyze_ago_session.py
+++ b/scripts/analyze_ago_session.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Analyze an ``ago --log-file`` session trace into an actionable report.
+
+A raw agent-host log is a flat stream of frames; eyeballing it tells you little
+about *how a turn actually went*. This turns one (or more) ``ago-session*.log``
+files into a per-turn summary plus **red flags** that point at concrete
+orchestrator improvements:
+
+  * a turn that ran many steps but wrote **zero files** (spinning, not building)
+  * step overshoot (final step index ≫ the planned ``total``)
+  * ``shell_timeout`` (a command run in watch/interactive mode that never exits)
+  * the **same command failing repeatedly** (thrash instead of changing tack)
+  * cost / token blow-ups
+
+It reads the fields already in the trace (``recv step``, ``tool_call``,
+``tool_result``, ``turn_end``) and, when present, the ``args=`` summary the CLI
+now logs — so a failing/looping command is named, not just counted.
+
+Usage:
+    python scripts/analyze_ago_session.py ~/ago-session_10.log
+    python scripts/analyze_ago_session.py ~/ago-session*.log --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+_TS = r"^(?P<ts>\S+)\s+DEBUG\s+"
+_RE_PROMPT = re.compile(_TS + r"send prompt (?P<bytes>\d+)B")
+_RE_STEP = re.compile(
+    _TS + r'recv step idx=(?P<idx>\d+) total=(?P<total>\d+) agent="(?P<agent>[^"]*)"'
+)
+_RE_TOOL_CALL = re.compile(
+    _TS + r"recv tool_call id=(?P<id>\S+) name=(?P<name>\S+)(?: args=(?P<args>.*))?$"
+)
+_RE_TOOL_RESULT = re.compile(
+    _TS + r"send tool_result id=(?P<id>\S+) status=(?P<status>\S+)(?P<rest>.*)$"
+)
+_RE_REASON = re.compile(r'reason="(?P<reason>[^"]*)"')
+_RE_ERRCODE = re.compile(r"error_code=(?P<code>\S+)")
+_RE_TURN_END = re.compile(
+    _TS + r'recv turn_end status="(?P<status>[^"]*)" steps=(?P<steps>\d+) '
+    r"in=(?P<in>\d+) out=(?P<out>\d+) cost=(?P<cost>[\d.]+) "
+    r'error="(?P<error>[^"]*)"'
+)
+
+# A turn is "expensive" / "long" past these; tunes only the red-flag wording.
+_COST_FLAG_USD = 0.10
+_OVERSHOOT_RATIO = 1.5
+
+
+@dataclass
+class Turn:
+    prompt_bytes: int = 0
+    agents: set[str] = field(default_factory=set)
+    max_step_idx: int = 0
+    total_steps: int = 0  # planned budget echoed by the meter
+    tool_counts: Counter = field(default_factory=Counter)
+    error_reasons: Counter = field(default_factory=Counter)
+    # id -> "name args" so a result can be attributed to its command.
+    _calls: dict[str, str] = field(default_factory=dict)
+    file_writes: list[str] = field(default_factory=list)
+    failed_commands: Counter = field(default_factory=Counter)
+    status: str = ""
+    steps: int = 0
+    tok_in: int = 0
+    tok_out: int = 0
+    cost_usd: float = 0.0
+    error: str = ""
+
+    @property
+    def tool_errors(self) -> int:
+        return sum(self.error_reasons.values())
+
+    def red_flags(self) -> list[str]:
+        flags: list[str] = []
+        if self.tool_counts.get("file_write", 0) == 0 and self.max_step_idx >= 5:
+            flags.append(f"0 file_write in {self.max_step_idx} steps — spinning, not building")
+        if self.total_steps and self.max_step_idx > self.total_steps * _OVERSHOOT_RATIO:
+            flags.append(f"step overshoot: {self.max_step_idx} vs planned {self.total_steps}")
+        if self.error_reasons.get("shell_timeout"):
+            flags.append(
+                f"{self.error_reasons['shell_timeout']}× shell_timeout — "
+                "a command ran in watch/interactive mode and never exited"
+            )
+        for cmd, n in self.failed_commands.items():
+            if n >= 3 and cmd:
+                flags.append(f"same command failed {n}×: {cmd}")
+        if self.cost_usd >= _COST_FLAG_USD:
+            flags.append(f"cost ${self.cost_usd:.4f} this turn")
+        return flags
+
+
+def parse_log(text: str) -> list[Turn]:
+    """Parse a raw session log into turns (segments between prompt and turn_end)."""
+    turns: list[Turn] = []
+    cur: Turn | None = None
+
+    def ensure() -> Turn:
+        nonlocal cur
+        if cur is None:
+            cur = Turn()
+            turns.append(cur)
+        return cur
+
+    for line in text.splitlines():
+        if m := _RE_PROMPT.search(line):
+            cur = Turn(prompt_bytes=int(m["bytes"]))
+            turns.append(cur)
+            continue
+        if m := _RE_STEP.search(line):
+            t = ensure()
+            t.max_step_idx = max(t.max_step_idx, int(m["idx"]))
+            t.total_steps = int(m["total"])
+            t.agents.add(m["agent"])
+            continue
+        if m := _RE_TOOL_CALL.search(line):
+            t = ensure()
+            t.tool_counts[m["name"]] += 1
+            label = f"{m['name']} {m['args']}".strip() if m["args"] else m["name"]
+            t._calls[m["id"]] = label
+            if m["name"] == "file_write" and m["args"]:
+                t.file_writes.append(m["args"])
+            continue
+        if m := _RE_TOOL_RESULT.search(line):
+            t = ensure()
+            if m["status"] != "ok":
+                rest = m["rest"]
+                reason = _RE_REASON.search(rest)
+                code = _RE_ERRCODE.search(rest)
+                label = (reason["reason"] if reason else None) or (
+                    code["code"] if code else "error"
+                )
+                t.error_reasons[label] += 1
+                cmd = t._calls.get(m["id"], "")
+                if cmd:
+                    t.failed_commands[cmd] += 1
+            continue
+        if m := _RE_TURN_END.search(line):
+            t = ensure()
+            t.status = m["status"]
+            t.steps = int(m["steps"])
+            t.tok_in = int(m["in"])
+            t.tok_out = int(m["out"])
+            t.cost_usd = float(m["cost"])
+            t.error = m["error"]
+            cur = None
+            continue
+
+    return turns
+
+
+def _turn_dict(i: int, t: Turn) -> dict[str, Any]:
+    return {
+        "turn": i,
+        "agents": sorted(t.agents),
+        "steps": t.steps or t.max_step_idx,
+        "planned_total": t.total_steps,
+        "status": t.status or "(running/unterminated)",
+        "tok_in": t.tok_in,
+        "tok_out": t.tok_out,
+        "cost_usd": round(t.cost_usd, 4),
+        "tools": dict(t.tool_counts),
+        "tool_errors": t.tool_errors,
+        "error_reasons": dict(t.error_reasons),
+        "file_writes": t.file_writes,
+        "red_flags": t.red_flags(),
+    }
+
+
+def format_report(turns: list[Turn]) -> str:
+    out: list[str] = []
+    out.append(f"{len(turns)} turn(s)\n")
+    header = (
+        f"{'#':>2} {'agents':<22} {'steps':>10} {'tok_in':>9} {'cost$':>8} "
+        f"{'wr':>3} {'err':>4} {'status':>8}"
+    )
+    out.append(header)
+    out.append("-" * len(header))
+    total_cost = 0.0
+    all_flags: list[str] = []
+    for i, t in enumerate(turns, 1):
+        total_cost += t.cost_usd
+        steps = f"{t.steps or t.max_step_idx}/{t.total_steps or '?'}"
+        agents = ",".join(sorted(t.agents))[:22]
+        out.append(
+            f"{i:>2} {agents:<22} {steps:>10} {t.tok_in:>9,} {t.cost_usd:>8.4f} "
+            f"{t.tool_counts.get('file_write', 0):>3} {t.tool_errors:>4} "
+            f"{(t.status or 'run'):>8}"
+        )
+        for flag in t.red_flags():
+            all_flags.append(f"turn {i}: {flag}")
+    out.append(f"\ntotal cost: ${total_cost:.4f}")
+
+    if all_flags:
+        out.append("\nRED FLAGS")
+        out.append("-" * 8)
+        out.extend(f"  ⚠ {f}" for f in all_flags)
+    else:
+        out.append("\nNo red flags.")
+
+    # Surface the most-failed commands across the whole session — the single
+    # most useful signal for "what is the agent getting stuck on".
+    failed: Counter = Counter()
+    for t in turns:
+        failed.update(t.failed_commands)
+    top = [(c, n) for c, n in failed.most_common(8) if c and n >= 2]
+    if top:
+        out.append("\nMOST-FAILED COMMANDS (count × command)")
+        out.append("-" * 38)
+        out.extend(f"  {n:>3} × {cmd}" for cmd, n in top)
+
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Analyze ago --log-file session traces into an actionable report."
+    )
+    parser.add_argument("logs", nargs="+", help="log file(s); globs allowed")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args(argv)
+
+    paths: list[str] = []
+    for pattern in args.logs:
+        paths.extend(sorted(glob.glob(pattern)) or [pattern])
+
+    turns: list[Turn] = []
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                turns.extend(parse_log(fh.read()))
+        except OSError as exc:
+            print(f"error: cannot read {path}: {exc}", file=sys.stderr)
+            return 2
+
+    if not turns:
+        print("No turns found in the given log(s).", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps([_turn_dict(i, t) for i, t in enumerate(turns, 1)], indent=2))
+    else:
+        print(format_report(turns))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_analyze_ago_session.py
+++ b/tests/test_analyze_ago_session.py
@@ -1,0 +1,99 @@
+"""Tests for the ago session-log analyzer (``scripts/analyze_ago_session.py``).
+
+``scripts/`` is not a package, so the module is loaded by file path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "scripts" / "analyze_ago_session.py"
+_spec = importlib.util.spec_from_file_location("analyze_ago_session", _MOD_PATH)
+assert _spec and _spec.loader
+analyzer = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass can resolve the module for type lookups.
+sys.modules["analyze_ago_session"] = analyzer
+_spec.loader.exec_module(analyzer)
+
+
+def _ts(s: str) -> str:
+    return f"2026-06-14T20:00:{s}Z DEBUG "
+
+
+SAMPLE = "\n".join(
+    [
+        # Turn 1: writes a file, then a watch-mode test command times out, and
+        # the step meter overshoots the planned budget.
+        _ts("00.0") + "send prompt 1500B",
+        _ts("01.0") + 'recv step idx=1 total=40 agent="team-lead" label=""',
+        _ts("02.0") + "recv tool_call id=a1 name=file_write args=src/App.test.js",
+        _ts("02.1") + "send tool_result id=a1 status=ok",
+        _ts("03.0") + "recv tool_call id=a2 name=shell_exec args=npm test",
+        _ts("04.0") + 'send tool_result id=a2 status=error reason="shell_timeout"',
+        _ts("05.0") + 'recv step idx=70 total=40 agent="frontend" label="working"',
+        _ts("06.0") + 'recv turn_end status="ok" steps=70 in=500000 out=8000 cost=0.5 error=""',
+        # Turn 2: the same command fails three times — thrash.
+        _ts("10.0") + "send prompt 100B",
+        _ts("11.0") + "recv tool_call id=b1 name=shell_exec args=pytest -q",
+        _ts("11.1") + 'send tool_result id=b1 status=error reason="shell_nonzero_exit"',
+        _ts("12.0") + "recv tool_call id=b2 name=shell_exec args=pytest -q",
+        _ts("12.1") + 'send tool_result id=b2 status=error reason="shell_nonzero_exit"',
+        _ts("13.0") + "recv tool_call id=b3 name=shell_exec args=pytest -q",
+        _ts("13.1") + 'send tool_result id=b3 status=error reason="shell_nonzero_exit"',
+        _ts("14.0") + 'recv step idx=8 total=40 agent="backend" label="working"',
+        _ts("15.0") + 'recv turn_end status="ok" steps=8 in=1000 out=10 cost=0.001 error=""',
+    ]
+)
+
+
+def test_parse_splits_turns_and_counts_tools():
+    turns = analyzer.parse_log(SAMPLE)
+    assert len(turns) == 2
+    t1, t2 = turns
+    assert t1.tool_counts["file_write"] == 1
+    assert t1.tool_counts["shell_exec"] == 1
+    assert t1.file_writes == ["src/App.test.js"]
+    assert t1.cost_usd == 0.5
+    assert t1.max_step_idx == 70
+    assert t2.tool_counts["shell_exec"] == 3
+    assert t2.tool_errors == 3
+
+
+def test_red_flags_catch_known_failure_modes():
+    t1, t2 = analyzer.parse_log(SAMPLE)
+    f1 = " | ".join(t1.red_flags())
+    assert "overshoot" in f1  # 70 ≫ 40
+    assert "shell_timeout" in f1  # watch-mode hang
+    assert "cost" in f1  # 0.5 ≥ threshold
+
+    f2 = " | ".join(t2.red_flags())
+    assert "same command failed 3" in f2
+    assert "pytest -q" in f2  # the actual command, thanks to args= logging
+
+
+def test_zero_write_spinning_flag():
+    log = "\n".join(
+        [
+            _ts("00.0") + "send prompt 200B",
+            *[
+                _ts(f"0{i}.0") + f'recv step idx={i} total=40 agent="backend" label="x"'
+                for i in range(1, 7)
+            ],
+            _ts("09.0") + "recv tool_call id=c1 name=file_read args=README.md",
+            _ts("09.1") + "send tool_result id=c1 status=ok",
+            _ts("10.0") + 'recv turn_end status="ok" steps=6 in=10 out=2 cost=0.0 error=""',
+        ]
+    )
+    (t,) = analyzer.parse_log(log)
+    assert any("0 file_write" in flag for flag in t.red_flags())
+
+
+def test_format_report_renders_table_and_flags():
+    report = analyzer.format_report(analyzer.parse_log(SAMPLE))
+    assert "turn(s)" in report
+    assert "RED FLAGS" in report
+    assert "MOST-FAILED COMMANDS" in report
+    assert "pytest -q" in report
+    assert "total cost: $0.50" in report


### PR DESCRIPTION
## Summary

Brings the `ago` CLI from **v0.5.27 → v0.5.32**: a client-side thrash guard for `--client-tools` turns, its follow-up fixes, convergence aids, and an after-the-fact session analyzer.

6 commits, **6 ahead / 0 behind `main`** (clean fast-forward).

## What's in it

- **`be10a4e` v0.5.28** — client-side thrash guard for `--client-tools` turns
- **`fa6a049` v0.5.29** — failure-density heuristic + `.ago.yaml` guard block
- **`7b22e31` v0.5.30** — fix thrash-guard deadlock when a tool call is blocked
- **`f448ead` v0.5.31** — char-boundary-safe arg/output preview truncation
- **`61d92ec` v0.5.32** — convergence aids: error digest + no-progress nudge
- **`1ecd4e4`** — `scripts/analyze_ago_session.py`: per-turn session report + thrash red-flags

The guard *prevents* thrash live; the analyzer *diagnoses* it after the fact from the `--log-file` trace alone (per-turn table + red flags: `0 file_write` spinning, step overshoot, `shell_timeout`, same command failing ≥3×, cost blow-ups).

## Tests

- `pytest tests/test_analyze_ago_session.py` → 4 passed
- Docs updated in `docs/ago-cli-improvements.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)