### PR TITLE
feat(context): shrink stale tool results so per-step context falls as it ages

### DIFF
--- a/docs/cache-strategy.md
+++ b/docs/cache-strategy.md
@@ -94,6 +94,28 @@ tokens — see [ago-cli-improvements.md](ago-cli-improvements.md), P0).
   tool responses are produced. The `agent.compactions` OTel span attribute
   counts how often it fired in a run.
 
+## Progressive relief: stale tool-result shrinking
+
+Compaction above only fires once the context crosses the threshold, and it
+elides by *age* (middle messages), not by *relevance*. But the bulk of a long
+run's bytes are old **tool results** — a `file_read` body or a verbose test/build
+log the agent has already acted on. `shrink_stale_tool_results()` runs **every
+step** (before the threshold check) and replaces the *content* of any `Role.TOOL`
+result older than the most recent `stale_tool_result_keep_recent` (default **6**)
+that is larger than `stale_tool_result_stub_over` chars (default **1200**) with a
+one-line stub — e.g. `[stale tool result elided — 4096 chars; began: '…']`. So
+the per-step context **shrinks as material becomes irrelevant** instead of only
+being cut at the threshold.
+
+- The message and its `tool_call_id` are **kept**, so provider tool-call pairing
+  stays intact and the agent can re-read deliberately if it genuinely needs the
+  detail (the convergence-loop steer already discourages gratuitous re-reads).
+- Motivated by a 2026-06-16 `--client-tools` test-fix turn that hit the
+  per-turn **cost cap** ($0.30) at 962k input tokens / 47 steps purely through
+  tool-result accumulation, stopping `test-engineer` before it converged.
+- `0` for either knob disables it. Composes with compaction: this trims the bulk
+  continuously, `compact_messages()` handles whatever remains.
+
 ---
 
 ## Integration Points (Where to Wire Cache)

--- a/src/agent_orchestrator/core/agent.py
+++ b/src/agent_orchestrator/core/agent.py
@@ -54,6 +54,18 @@ class AgentConfig:
     # large file_read / shell_exec can otherwise dominate the prompt for the
     # rest of the run (see docs/ago-cli-improvements.md, P1). 0 disables.
     max_tool_result_chars: int = 8000
+    # Progressive context relief. A file_read / shell_exec result is usually only
+    # needed for the next few steps; once it is older than the most recent
+    # ``stale_tool_result_keep_recent`` TOOL messages the agent has already acted
+    # on it, yet its verbatim bytes keep being re-sent on every later step (the
+    # 962k-input / $0.34 test-fix turn on 2026-06-16 was cost-capped purely by
+    # this accumulation). Each step, the content of stale tool results larger
+    # than ``stale_tool_result_stub_over`` chars is replaced with a one-line stub
+    # that still names the call — so the context SHRINKS as material becomes
+    # irrelevant, instead of only being cut at the compaction threshold. The
+    # agent can re-read deliberately if it truly needs the detail. 0 disables.
+    stale_tool_result_keep_recent: int = 6
+    stale_tool_result_stub_over: int = 1200
     # Mid-run context compaction (docs/ago-cli-improvements.md, P0). When the
     # context the provider just billed exceeds this many input tokens, the
     # oldest middle messages are elided — keeping task setup + recent turns —
@@ -148,6 +160,57 @@ def cap_tool_result_content(text: str, limit: int) -> str:
     head = text[:head_len]
     tail = text[-tail_len:] if tail_len > 0 else ""
     return f"{head}{marker.format(n=dropped)}{tail}"
+
+
+def shrink_stale_tool_results(
+    messages: list[Message],
+    *,
+    keep_recent: int,
+    stub_over: int,
+) -> tuple[list[Message], int]:
+    """Stub the content of TOOL results older than the most recent ``keep_recent``.
+
+    Within a run a tool result (a ``file_read`` body, a test/build log) is
+    usually only needed for the next handful of steps; after the agent has acted
+    on it the verbatim bytes are dead weight that every later LLM call re-sends,
+    so context — and cost — grow with run length. This replaces the *content* of
+    stale tool results larger than ``stub_over`` chars with a compact stub that
+    still names the call and its original size, **keeping the message and its
+    ``tool_call_id``** so provider tool-call pairing stays intact and the agent
+    can re-read deliberately if it genuinely needs the detail.
+
+    Unlike :func:`compact_messages` (a threshold-triggered head/tail elision),
+    this is meant to run every step so the context *shrinks as material ages
+    out* rather than only being cut once the threshold is crossed. The two
+    compose: this trims the bulk continuously, compaction handles the rest.
+
+    Returns ``(messages, shrunk_count)``. When nothing changes the original list
+    is returned unchanged; otherwise a new list of (mostly shared) messages is
+    returned and the inputs are never mutated.
+    """
+    if keep_recent < 0 or stub_over <= 0:
+        return messages, 0
+    tool_idxs = [i for i, m in enumerate(messages) if m.role == Role.TOOL]
+    if len(tool_idxs) <= keep_recent:
+        return messages, 0
+    stale = set(tool_idxs[: len(tool_idxs) - keep_recent])
+    from dataclasses import replace
+
+    out: list[Message] = []
+    shrunk = 0
+    for i, m in enumerate(messages):
+        content = m.content or ""
+        if i in stale and len(content) > stub_over:
+            first_line = content.splitlines()[0] if content else ""
+            preview = first_line[:80]
+            stub = f"[stale tool result elided — {len(content)} chars; began: {preview!r}]"
+            out.append(replace(m, content=stub))
+            shrunk += 1
+        else:
+            out.append(m)
+    if shrunk == 0:
+        return messages, 0
+    return out, shrunk
 
 
 def estimate_message_tokens(messages: list[Message]) -> int:

--- a/src/agent_orchestrator/dashboard/agent_runner.py
+++ b/src/agent_orchestrator/dashboard/agent_runner.py
@@ -27,6 +27,7 @@ from ..core.agent import (
     cap_tool_result_content,
     compact_messages,
     estimate_message_tokens,
+    shrink_stale_tool_results,
 )
 from ..core.tool_recovery import recover_dangling_tool_calls
 from ..core.cache import InMemoryCache
@@ -447,6 +448,18 @@ async def _instrumented_execute(
                     "step_log": step_log,
                     "fallback_log": fallback_log,
                 },
+            )
+
+        # Progressive context relief BEFORE the threshold cut: stub the bulk of
+        # old tool-result bytes (file/test output) that the agent has already
+        # acted on, so the per-step context shrinks as material ages out instead
+        # of only being cut at the compaction threshold. This is what bounded a
+        # 962k-input test-fix turn that was cost-capped purely by accumulation.
+        if config.stale_tool_result_keep_recent >= 0 and config.stale_tool_result_stub_over > 0:
+            messages, _shrunk = shrink_stale_tool_results(
+                messages,
+                keep_recent=config.stale_tool_result_keep_recent,
+                stub_over=config.stale_tool_result_stub_over,
             )
 
         # Mid-run context compaction (mirrors core.Agent.execute, reusing the

--- a/tests/test_agent_context_cap.py
+++ b/tests/test_agent_context_cap.py
@@ -710,3 +710,67 @@ async def test_backoff_disabled_lets_command_rerun():
     # With back-off off, the command runs every step (no short-circuit).
     assert skill.calls == 5
     assert not any("[not executed]" in (m.content or "") for m in agent._messages)
+
+
+# ---------------------------------------------------------------------------
+# Progressive context relief: shrink_stale_tool_results
+# ---------------------------------------------------------------------------
+
+
+def _msgs_with_tool_results(n: int, body_chars: int = 4000):
+    """user task + n (assistant tool_call, tool result) pairs."""
+    out = [Message(role=Role.USER, content="task")]
+    for i in range(n):
+        out.append(Message(role=Role.ASSISTANT, content=f"calling {i}"))
+        out.append(Message(role=Role.TOOL, content="X" * body_chars, tool_call_id=f"tc-{i}"))
+    return out
+
+
+def test_shrink_stale_keeps_recent_tool_results_verbatim():
+    from agent_orchestrator.core.agent import shrink_stale_tool_results
+
+    msgs = _msgs_with_tool_results(10, body_chars=4000)
+    out, shrunk = shrink_stale_tool_results(msgs, keep_recent=6, stub_over=1200)
+    # 10 tool results, keep last 6 → 4 oldest stubbed
+    assert shrunk == 4
+    tool_msgs = [m for m in out if m.role == Role.TOOL]
+    # the last 6 stay full
+    assert all(len(m.content) == 4000 for m in tool_msgs[-6:])
+    # the first 4 are stubbed and much smaller
+    assert all("stale tool result elided" in m.content for m in tool_msgs[:4])
+    assert all(len(m.content) < 200 for m in tool_msgs[:4])
+
+
+def test_shrink_stale_preserves_tool_call_id():
+    from agent_orchestrator.core.agent import shrink_stale_tool_results
+
+    msgs = _msgs_with_tool_results(10, body_chars=4000)
+    out, _ = shrink_stale_tool_results(msgs, keep_recent=6, stub_over=1200)
+    stubbed = [m for m in out if m.role == Role.TOOL and "elided" in m.content]
+    # pairing must survive so providers don't reject an orphaned result
+    assert all(m.tool_call_id is not None for m in stubbed)
+
+
+def test_shrink_stale_noop_when_few_tool_results():
+    from agent_orchestrator.core.agent import shrink_stale_tool_results
+
+    msgs = _msgs_with_tool_results(5, body_chars=4000)
+    out, shrunk = shrink_stale_tool_results(msgs, keep_recent=6, stub_over=1200)
+    assert shrunk == 0 and out is msgs
+
+
+def test_shrink_stale_skips_small_results():
+    from agent_orchestrator.core.agent import shrink_stale_tool_results
+
+    # old results are below the stub_over threshold → left alone
+    msgs = _msgs_with_tool_results(10, body_chars=300)
+    out, shrunk = shrink_stale_tool_results(msgs, keep_recent=6, stub_over=1200)
+    assert shrunk == 0 and out is msgs
+
+
+def test_shrink_stale_disabled_by_zero():
+    from agent_orchestrator.core.agent import shrink_stale_tool_results
+
+    msgs = _msgs_with_tool_results(10, body_chars=4000)
+    out, shrunk = shrink_stale_tool_results(msgs, keep_recent=6, stub_over=0)
+    assert shrunk == 0 and out is msgs


### PR DESCRIPTION
## Why

A 2026-06-16 `--client-tools` test-fix turn hit the per-turn **cost cap ($0.30)** at **962k input tokens / 47 steps**. `test-engineer` understood the task and was fixing tests cleanly (10 writes, 34 ok results) — it was stopped by **budget, not confusion**. Every step re-sent the full bodies of all previously-read files / test logs, so cost ballooned. Threshold compaction (60k) only cuts by *age* once crossed; the bulk of the bytes are old **tool results** the agent already acted on.

This is the user's own intuition: *the context should shrink as soon as something is no longer relevant.*

## What

- **`shrink_stale_tool_results()`** (`core/agent.py`): every step, stub the content of `Role.TOOL` results older than the most recent `stale_tool_result_keep_recent` (**6**) that exceed `stale_tool_result_stub_over` (**1200**) chars → `[stale tool result elided — N chars; began: '…']`. The message and its `tool_call_id` are kept (pairing intact; the agent can re-read deliberately).
- Wired into `_instrumented_execute` **before** the threshold compaction; the two compose — this trims the bulk continuously, `compact_messages()` handles the rest.

## Tests & docs

- +5 in `test_agent_context_cap.py` (keep-recent verbatim, tool_call_id preserved, no-op when few/small, disable knob). Full suite **2528 passed**, lint clean.
- `docs/cache-strategy.md` "Progressive relief" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)