### PR TITLE
feat(orchestrator): anchor each turn on the latest user message (no task inertia)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -33,6 +33,14 @@ in `run_team` in `dashboard/agent_runner.py`). The plan prompt enforces:
 - **Outcome first.** Each assignment is phrased as a concrete edit ("add X to
   file Y"), never as "investigate" / "analyze" / "diagnose" / "review" — unless
   the user explicitly asked only for analysis.
+- **Current-turn anchor.** team-lead plans for the user's *latest* message;
+  earlier conversation is background only. A new or terse instruction in a
+  context saturated by a prior task (e.g. "write a rules file" after a long
+  test-fixing session) defines THIS turn's goal — team-lead switches to it
+  instead of continuing the previous task by inertia. The sub-agent steer
+  carries the matching "stay on this task" rule so the executor doesn't drift
+  back either. (Added after a 16-byte instruction was swallowed by a 900k-token
+  context, 2026-06-16.)
 - **Fan out across layers** when a change spans them (API + UI → `backend` AND
   `frontend`); otherwise keep it to a single agent.
 - **Bug-fix / debug / "make it work" tasks → one owning agent, never a team.**

--- a/src/agent_orchestrator/dashboard/agent_runner.py
+++ b/src/agent_orchestrator/dashboard/agent_runner.py
@@ -53,6 +53,11 @@ _MINIMAL_CHANGES_STEER = (
     "*_SUMMARY.md, *_EVIDENCE.md, *_COMPLETE.md, CLEANUP_REPORT.md) — report "
     "what you did in your final reply, not as committed files. Do not "
     "restructure, rename, or reformat code that is unrelated to the task.\n\n"
+    "Stay on THIS task: the task description you were given is the goal for this "
+    "turn. Any earlier conversation is background context only — do exactly what "
+    "the task asks and nothing more. If the task is unrelated to prior work (e.g. "
+    "writing a small config / notes file after a coding session), do just that; "
+    "do not drift back into the previous task.\n\n"
     "Outcome requirement: if the task asks you to fix, implement, add, change, "
     "build, or create something, you MUST apply the change with file_write / "
     "edit before finishing — reading and exploring are only preparation. Ending "
@@ -1169,6 +1174,14 @@ async def run_team(
         messages=plan_messages,
         system=(
             "You are a team lead. Analyze the task and select the best agents.\n\n"
+            "CURRENT-TURN ANCHOR: plan for the user's LATEST message (the task "
+            "below) — that is THIS turn's goal. Earlier conversation is background "
+            "only. If the new message is a different or unrelated request from "
+            "what the conversation was doing (e.g. 'write a config/notes file' "
+            "after a long test-fixing session), SWITCH to it — do not keep "
+            "decomposing the previous task by inertia. A short or terse new "
+            "message still defines this turn; take it literally and do exactly "
+            "what it asks, nothing more.\n\n"
             f"{agent_catalog}\n\n"
             "Respond with ONLY a JSON array of assignments (max 5). "
             'Each item must have "agent" (exact name from the list) and "task" (specific instructions).\n'

--- a/tests/test_prompt_rules.py
+++ b/tests/test_prompt_rules.py
@@ -119,6 +119,27 @@ def test_team_lead_plan_prompt_keeps_fixes_single_agent() -> None:
     assert "redundant exploration" in low
 
 
+def test_team_lead_plan_prompt_anchors_on_current_turn() -> None:
+    """A new/terse instruction in a saturated conversation must define THIS
+    turn's goal — team-lead must not keep decomposing the prior task by inertia.
+    Added after a 16-byte 'write a rules file' message was swallowed by a 900k-
+    token test-fixing context (2026-06-16)."""
+    src = inspect.getsource(agent_runner.run_team)
+    low = src.lower()
+    assert "current-turn anchor" in low
+    assert "by inertia" in low
+    assert "background" in low
+
+
+def test_minimal_changes_steer_stays_on_current_task() -> None:
+    """Sub-agents must treat their task as THIS turn's goal and not drift back
+    into prior work when the new task is unrelated."""
+    steer = agent_runner._MINIMAL_CHANGES_STEER.lower()
+    assert "stay on this task" in steer
+    assert "background context only" in steer
+    assert "drift back into the previous task" in steer
+
+
 def test_team_lead_plan_prompt_routes_tests_to_test_engineer() -> None:
     """Test work (make tests pass / fix failing tests / coverage) must route to
     the dedicated test-engineer, not be split across backend+frontend+devops."""


### PR DESCRIPTION
## Why

A 16-byte "write a rules file" instruction, sent mid-conversation, was **swallowed by a 900k-token test-fixing context**: team-lead and the sub-agent kept doing the PREVIOUS task (explored backend tests, hit the step cap) instead of the new, unrelated request. A short/terse new message in a saturated context must still define the current turn.

## What

- **team-lead plan prompt** — a `CURRENT-TURN ANCHOR`: plan for the user's *latest* message; earlier conversation is background; if the new message is a different request, **switch to it**, don't continue the prior task by inertia; take a terse message literally.
- **`_MINIMAL_CHANGES_STEER`** — a matching "stay on THIS task" rule so the executor doesn't drift back into prior work when the new task is unrelated.

Composes with the just-shipped progressive context relief (which lightens the prior-task bytes so the new instruction isn't drowned).

## Tests & docs

- +2 in `test_prompt_rules.py`. Lint clean.
- `docs/agents.md` routing section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)